### PR TITLE
fix a wrong https reference that breaks auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,22 @@ chown deploy authorized_keys
 chmod 600 authorized_keys
 
 
-Also, in /var/www/canvas, we will want to make sure it is all set up correctly for our repo:
+Also, in /var/canvas, we will want to make sure it is all set up correctly for our repo:
 
 git remote -v
 
-If it doesn't show beyond-z, fit it with:
+If it doesn't show beyond-z, fix it with:
 git remote set-url origin git@github.com:beyond-z/canvas-lms.git
 
+Also check
+git config user.name
+
+If it isn't set, run:
+
+git config user.email 'tech@beyondz.org'
+git config user.name 'Beyond Z'
+
+so it doesn't complain about a missing identity when you add a new user.
 
 Lastly, we want to make a restart script that the deploy user can run for automatic apache restarting:
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Also, in /var/www/canvas, we will want to make sure it is all set up correctly f
 git remote -v
 
 If it doesn't show beyond-z, fit it with:
-git remote set-url origin https://github.com/beyond-z/canvas-lms.git
+git remote set-url origin git@github.com:beyond-z/canvas-lms.git
 
 
 Lastly, we want to make a restart script that the deploy user can run for automatic apache restarting:


### PR DESCRIPTION
The https one doesn't work with keys, it should have been set to git. This is done on the server rather than the client so nothing you have to do now, but the correct doc is important for reproducing.
