### PR TITLE
Make change password link to BZ instead of doing it in canvas

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,6 +23,15 @@ module ApplicationHelper
   include LocaleSelection
   include Canvas::LockExplanation
 
+  def beyondz_app_domain
+    bz_host = request.host.sub('staging', '')
+    if bz_host.starts_with?('.')
+      bz_host[1 .. -1]
+    else
+      bz_host
+    end
+  end
+
   def context_user_name(context, user)
     return nil unless user
     return user.short_name if !context && user.respond_to?(:short_name)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,7 +24,7 @@ module ApplicationHelper
   include Canvas::LockExplanation
 
   def beyondz_app_domain
-    bz_host = request.host.sub('staging', '')
+    bz_host = request.host.sub('portal', '')
     if bz_host.starts_with?('.')
       bz_host[1 .. -1]
     else

--- a/app/views/profile/profile.html.erb
+++ b/app/views/profile/profile.html.erb
@@ -101,10 +101,14 @@
       </td>
     </tr>
   <% end %>
-  <% if !@password_pseudonyms.empty? %>
   <tr class="edit_data_row select_change_password_row" style="display: none;">
     <td><%= before_label(:password, "Password") %></td>
-    <td><label for="change_password_checkbox" class="checkbox"><input type="checkbox" id="change_password_checkbox" name="pseudonym[change_password]" value="1"/><%= t('labels.change_password', "Change Password") %></label></td>
+    <td><a href="//<%=beyondz_app_domain%>/users/registration/edit"><%= t('labels.change_password', "Change Password") %></a></td>
+  </tr>
+  <% if false && !@password_pseudonyms.empty? %>
+  <tr class="edit_data_row select_change_password_row" style="display: none;">
+    <td><%= before_label(:password, "password") %></td>
+    <td><label for="change_password_checkbox" class="checkbox"><input type="checkbox" id="change_password_checkbox" name="pseudonym[change_password]" value="1"/><%= t('labels.change_password', "change password") %></label></td>
   </tr>
   <% end %>
   <tr class="change_password_row" style="display: none;">


### PR DESCRIPTION
It determines the bz domain from the current domain to avoid adding a new config option. By removing 'portal' from the URL, it leaves us with the real thing. This will need to be updated if we ever change URL schemes.
