### PR TITLE
Make Capistrano config explicit per server

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -4,8 +4,6 @@ lock '3.2.1'
 set :application, 'canvas'
 set :repo_url, 'git@github.com:beyond-z/canvas-lms.git'
 
-set :branch, 'bz-master'
-
 # Default branch is :master
 # ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }.call
 

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -8,6 +8,8 @@ role :app, %w{deploy@portal.beyondz.org}
 role :web, %w{deploy@portal.beyondz.org}
 role :db,  %w{deploy@portal.beyondz.org}
 
+set :branch, 'bz-master'
+
 # Extended Server Syntax
 # ======================
 # This can be used to drop a more detailed server definition into the


### PR DESCRIPTION
Basically, change the base deploy.rb file to not set the branch and move the branch config to production.rb and staging.rb.
