### PR TITLE
Cleanup README and capistrano

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,59 +86,7 @@ Dev wise, we need to use a different branch:
   * upstream things that work for us too are merged from the off master branch into our off BZ branch
 		(git checkout beyondz; git checkout -b integrate_that_thing_with_us; git merge that_thing)
 
-
-Production Deploy for BZ
-===========
-
-Check out our branch to your local machine and run bundle install. This will install capistrano locally. Also run ssh-agent locally (refer to its instructions for a full install, but generally: run the program, set the environment it spits out, then do ssh-add to add your identity for forwarding). Without the ssh-agent, cap deploy will complain it couldn't log into github from the server.
-
-On the server, we create a user called 'deploy'.
-
-adduser deploy
-passwd -l deploy # prohibit regular login
-cd ~deploy
-mkdir .ssh
-chown deploy ssh
-chmod .ssh 600
-cd .ssh
-touch authorized_keys # put in a different key for each individual deployer. Should match what you use for github for easiest access to repo
-chown deploy authorized_keys
-chmod 600 authorized_keys
-
-
-Also, in /var/canvas, we will want to make sure it is all set up correctly for our repo:
-
-git remote -v
-
-If it doesn't show beyond-z, fix it with:
-git remote set-url origin git@github.com:beyond-z/canvas-lms.git
-
-Also check
-git config user.name
-
-If it isn't set, run:
-
-git config user.email 'tech@beyondz.org'
-git config user.name 'Beyond Z'
-
-so it doesn't complain about a missing identity when you add a new user.
-
-Lastly, we want to make a restart script that the deploy user can run for automatic apache restarting:
-
-echo 'deploy ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/deploy
-chmod 0440 /etc/sudoers.d/deploy
-
-
-
-Do that stuff only once. After the server is prepared, just run this locally:
-
-$ bundle exec cap staging deploy:update
-
-from the canvas folder and it should work to update code from our github repo. If you get a "remote disconnect", double check the ssh-agent setup and environment variables.
-
-
-The rest is just the original Canvas README contents:
-
+# The rest is just the original Canvas README contents:
 
 Canvas LMS
 ======

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,10 @@
+require 'capistrano/ext/multistage'
+
 # config valid only for Capistrano 3.1
 lock '3.2.1'
+
+set :stages, ["staging", "production"]
+set :default_stage, "staging"
 
 set :application, 'canvas'
 set :repo_url, 'git@github.com:beyond-z/canvas-lms.git'


### PR DESCRIPTION
- Deployment instructions have been moved to private location.  
- Enable multistage on capistrano to help deploy to multiple servers.  Set staging as the default.
