### PR TITLE
Capistrano deploys require the Gemfile.lock file to be in source control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@
 /db/*.sqlite*
 /db/*sql
 /exports/
-Gemfile.lock
+#Gemfile.lock # Commenting out and checking in Gemfile.lock to get Capistrano deploys working.  It runs bundle install --deployment which requires this to be checked in.
 Gemfile.lock3
 /log/
 /public/app/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,786 @@
+GIT
+  remote: https://github.com/cavi21/letter_opener.git
+  revision: 3be81cb10e4c71f79278db22aa5e10aca64418f0
+  specs:
+    letter_opener (1.0.0)
+      launchy (>= 2.2.0)
+
+GIT
+  remote: https://github.com/kreynolds/cassandra-cql.git
+  revision: beed72e249d02cebc850a4b92b468c8b64b12257
+  ref: beed72e249d02cebc850a4b92b468c8b64b12257
+  specs:
+    cassandra-cql (1.2.2)
+      simple_uuid (>= 0.2.0)
+      thrift_client (>= 0.7.1, < 0.9)
+
+GIT
+  remote: https://github.com/makandra/rails.git
+  revision: e86daf8ff727d5efc0040c876ba00c9444a5d915
+  ref: e86daf8ff727d5efc0040c876ba00c9444a5d915
+  branch: 2-3-lts
+  specs:
+    actionmailer (2.3.18)
+      actionpack (= 2.3.18)
+    actionpack (2.3.18)
+      activesupport (= 2.3.18)
+      rack (~> 1.1.0)
+    activerecord (2.3.18)
+      activesupport (= 2.3.18)
+    activeresource (2.3.18)
+      activesupport (= 2.3.18)
+    activesupport (2.3.18)
+    rails (2.3.18)
+      actionmailer (= 2.3.18)
+      actionpack (= 2.3.18)
+      activerecord (= 2.3.18)
+      activeresource (= 2.3.18)
+      activesupport (= 2.3.18)
+      rake (>= 0.8.3)
+
+GIT
+  remote: https://github.com/rubyzip/rubyzip.git
+  revision: 2697c7ea4fba6dca66acd4793965501b06ea8df6
+  ref: 2697c7ea4fba6dca66acd4793965501b06ea8df6
+  specs:
+    rubyzip (1.1.0)
+
+PATH
+  remote: gems/active_polymorph
+  specs:
+    active_polymorph (0.0.1)
+      activerecord (~> 2.3)
+
+PATH
+  remote: gems/activesupport-suspend_callbacks
+  specs:
+    activesupport-suspend_callbacks (0.0.1)
+      activesupport (~> 2.3)
+
+PATH
+  remote: gems/acts_as_list
+  specs:
+    acts_as_list (0.0.1)
+      rails (~> 2.3)
+
+PATH
+  remote: gems/adheres_to_policy
+  specs:
+    adheres_to_policy (0.0.1)
+      rails (~> 2.3)
+
+PATH
+  remote: gems/bookmarked_collection
+  specs:
+    bookmarked_collection (1.0.0)
+      fake_arel (= 1.5.0)
+      folio-pagination-legacy (= 0.0.3)
+      json_token
+      paginated_collection
+      rails (~> 2.3)
+      will_paginate (= 2.3.15)
+
+PATH
+  remote: gems/canvas_breach_mitigation
+  specs:
+    canvas_breach_mitigation (0.0.1)
+
+PATH
+  remote: gems/canvas_cassandra
+  specs:
+    canvas_cassandra (0.0.1)
+      cassandra-cql (= 1.2.2)
+
+PATH
+  remote: gems/canvas_color
+  specs:
+    canvas_color (0.0.1)
+
+PATH
+  remote: gems/canvas_crummy
+  specs:
+    canvas_crummy (0.0.1)
+
+PATH
+  remote: gems/canvas_ember_url
+  specs:
+    canvas_ember_url (1.0.0)
+
+PATH
+  remote: gems/canvas_ext
+  specs:
+    canvas_ext (1.0.0)
+      activesupport (~> 2.3)
+
+PATH
+  remote: gems/canvas_http
+  specs:
+    canvas_http (1.0.0)
+
+PATH
+  remote: gems/canvas_kaltura
+  specs:
+    canvas_kaltura (1.0.0)
+      canvas_http
+      canvas_slug
+      canvas_sort
+      libxml-ruby (= 2.6.0)
+      multipart
+      nokogiri (= 1.5.6)
+
+PATH
+  remote: gems/canvas_mimetype_fu
+  specs:
+    canvas_mimetype_fu (0.0.1)
+
+PATH
+  remote: gems/canvas_quiz_statistics
+  specs:
+    canvas_quiz_statistics (0.1.0)
+      activesupport
+      html_text_helper
+
+PATH
+  remote: gems/canvas_sanitize
+  specs:
+    canvas_sanitize (0.0.1)
+
+PATH
+  remote: gems/canvas_slug
+  specs:
+    canvas_slug (0.0.1)
+
+PATH
+  remote: gems/canvas_sort
+  specs:
+    canvas_sort (1.0.0)
+
+PATH
+  remote: gems/canvas_statsd
+  specs:
+    canvas_statsd (1.0.0)
+      statsd-ruby (= 1.0.0)
+
+PATH
+  remote: gems/canvas_stringex
+  specs:
+    canvas_stringex (0.0.1)
+      fake_arel (~> 1.5)
+      rails (~> 2.3)
+
+PATH
+  remote: gems/canvas_text_helper
+  specs:
+    canvas_text_helper (0.0.1)
+      i18n
+
+PATH
+  remote: gems/canvas_time
+  specs:
+    canvas_time (1.0.0)
+      activesupport (~> 2.3.17)
+      tzinfo (= 0.3.35)
+
+PATH
+  remote: gems/canvas_uuid
+  specs:
+    canvas_uuid (0.0.1)
+      uuid (= 2.3.2)
+
+PATH
+  remote: gems/event_stream
+  specs:
+    event_stream (0.0.1)
+      bookmarked_collection
+      canvas_cassandra
+      canvas_statsd
+      canvas_uuid
+      json_token
+      paginated_collection
+      rails (~> 2.3)
+
+PATH
+  remote: gems/facebook
+  specs:
+    facebook (1.0.0)
+
+PATH
+  remote: gems/google_docs
+  specs:
+    google_docs (1.0.0)
+      oauth-instructure (= 0.4.10)
+      ratom-instructure (= 0.6.9)
+
+PATH
+  remote: gems/handlebars_tasks
+  specs:
+    handlebars_tasks (0.0.1)
+      compass
+      execjs (= 1.4.0)
+      i18n_extraction
+      sass
+
+PATH
+  remote: gems/html_text_helper
+  specs:
+    html_text_helper (0.0.1)
+      activesupport (~> 2.3)
+      canvas_text_helper
+      nokogiri (= 1.5.6)
+      sanitize (= 2.0.3)
+
+PATH
+  remote: gems/i18n_extraction
+  specs:
+    i18n_extraction (0.0.1)
+      activesupport (~> 2.3)
+      ruby_parser (= 3.6.1)
+      sexp_processor (= 4.2.1)
+
+PATH
+  remote: gems/i18n_tasks
+  specs:
+    i18n_tasks (0.0.1)
+      activesupport (~> 2.3)
+      i18n (= 0.6.8)
+      i18n_extraction
+      ruby_parser (= 3.6.1)
+      utf8_cleaner
+      ya2yaml (= 0.30)
+
+PATH
+  remote: gems/incoming_mail_processor
+  specs:
+    incoming_mail_processor (0.0.1)
+      activesupport (~> 2.3)
+      html_text_helper
+      mail (= 2.5.4)
+      utf8_cleaner
+
+PATH
+  remote: gems/json_token
+  specs:
+    json_token (0.0.1)
+      json (= 1.8.1)
+
+PATH
+  remote: gems/linked_in
+  specs:
+    linked_in (1.0.0)
+      nokogiri (= 1.5.6)
+      oauth-instructure (= 0.4.10)
+
+PATH
+  remote: gems/lti_outbound
+  specs:
+    lti_outbound (0.0.1)
+      i18n (= 0.6.8)
+      oauth-instructure (= 0.4.10)
+
+PATH
+  remote: gems/multipart
+  specs:
+    multipart (0.0.1)
+      canvas_slug
+      mime-types (= 1.17.2)
+
+PATH
+  remote: gems/paginated_collection
+  specs:
+    paginated_collection (1.0.0)
+      folio-pagination-legacy (= 0.0.3)
+      will_paginate (= 2.3.15)
+
+PATH
+  remote: gems/twitter
+  specs:
+    twitter (1.0.0)
+      html_text_helper
+
+PATH
+  remote: gems/utf8_cleaner
+  specs:
+    utf8_cleaner (0.0.1)
+
+PATH
+  remote: gems/workflow
+  specs:
+    workflow (0.0.1)
+      rails (~> 2.3)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    active_model_serializers_rails_2.3 (0.9.0.alpha1)
+    addressable (2.3.5)
+    adobe_connect (1.0.0)
+      activesupport (>= 2.3.17)
+      nokogiri (~> 1.5.5)
+      rake (>= 0.9.2)
+    authlogic (2.1.3)
+      activesupport
+    autoprefixer-rails (1.1.20140512)
+      execjs
+    aws-sdk (1.21.0)
+      json (~> 1.4)
+      nokogiri (>= 1.4.4, < 1.6.0)
+      uuidtools (~> 2.1)
+    barby (0.5.0)
+    bcrypt-ruby (3.0.1)
+    bluecloth (2.0.10)
+    builder (3.0.0)
+    bullet (4.5.0)
+      uniform_notifier
+    byebug (3.1.2)
+      columnize (~> 0.8)
+      debugger-linecache (~> 1.2)
+    canvas_connect (0.3.5)
+      adobe_connect (~> 1.0.0)
+      rake (>= 0.9.6)
+    canvas_webex (0.14)
+    capistrano (3.2.1)
+      i18n
+      rake (>= 10.0.0)
+      sshkit (~> 1.3)
+    capistrano-bundler (1.1.3)
+      capistrano (~> 3.1)
+      sshkit (~> 1.2)
+    capistrano-passenger (0.0.1)
+      capistrano (~> 3.0)
+    capistrano-rails (1.1.2)
+      capistrano (~> 3.1)
+      capistrano-bundler (~> 1.1)
+    childprocess (0.5.0)
+      ffi (~> 1.0, >= 1.0.11)
+    chunky_png (1.3.0)
+    coderay (1.1.0)
+    coffee-script (2.2.0)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.6.2)
+    colored (1.2)
+    colorize (0.7.3)
+    columnize (0.8.9)
+    compass (0.12.4)
+      chunky_png (~> 1.2)
+      fssm (>= 0.2.7)
+      sass (~> 3.2.17)
+    crack (0.4.1)
+      safe_yaml (~> 0.9.0)
+    crocodoc-ruby (0.0.1)
+      json
+    cssmin (1.0.3)
+    daemons (1.1.0)
+    debugger (1.6.6)
+      columnize (>= 0.3.1)
+      debugger-linecache (~> 1.2.0)
+      debugger-ruby_core_source (~> 1.3.2)
+    debugger-linecache (1.2.0)
+    debugger-ruby_core_source (1.3.5)
+    diff-lcs (1.1.3)
+    docile (1.1.3)
+    dress_code (1.0.2)
+      colored
+      mustache
+      pygments.rb
+      redcarpet
+    encrypted_cookie_store-instructure (1.0.6)
+    erubis (2.7.0)
+    eventmachine (1.0.3)
+    execjs (1.4.0)
+      multi_json (~> 1.0)
+    fake_arel (1.5.0)
+      activerecord (~> 2.3.11)
+    fake_rails3_routes (1.0.4)
+      journey (= 1.0.4)
+    ffi (1.1.5)
+    ffi-icu (0.1.2)
+      ffi (~> 1.0, >= 1.0.9)
+    folio-pagination-legacy (0.0.3)
+    foreigner (0.9.2)
+    formatador (0.2.5)
+    fssm (0.2.10)
+    guard (1.8.0)
+      formatador (>= 0.2.4)
+      listen (>= 1.0.0)
+      lumberjack (>= 1.0.2)
+      pry (>= 0.9.10)
+      thor (>= 0.14.6)
+    hairtrigger (0.2.9)
+      activerecord (>= 2.3)
+      ruby2ruby (~> 2.0.6)
+      ruby_parser (>= 3.5)
+    happymapper (0.4.1)
+      libxml-ruby (~> 2.0)
+    hashdiff (0.2.0)
+    hashery (1.3.0)
+    hashie (2.0.5)
+    highline (1.6.1)
+    hoe (3.8.1)
+      rake (>= 0.8, < 11.0)
+    i18n (0.6.8)
+    i18nema (0.0.7)
+      i18n (>= 0.5)
+    icalendar (1.5.4)
+    iconv (1.0.4)
+    instructure-active_model-better_errors (1.6.5.rails2.3)
+    instructure-redis-store (1.0.0.2.instructure1)
+      redis (= 3.0.1)
+      redis (= 3.0.1)
+    jammit (0.6.6)
+      cssmin (>= 1.0.3)
+      jsmin (>= 1.0.1)
+    journey (1.0.4)
+    jsmin (1.0.1)
+    json (1.8.1)
+    launchy (2.4.2)
+      addressable (~> 2.3)
+    libxml-ruby (2.6.0)
+    listen (1.3.1)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+      rb-kqueue (>= 0.2)
+    lumberjack (1.0.9)
+    macaddr (1.0.0)
+    mail (2.5.4)
+      mime-types (~> 1.16)
+      treetop (~> 1.4.8)
+    marginalia (1.1.3)
+      actionpack (>= 2.3, < 3.3)
+      activerecord (>= 2.3, < 3.3)
+    metaclass (0.0.2)
+    method_source (0.8.2)
+    mime-types (1.17.2)
+    mini_magick (1.3.2)
+      subexec (~> 0.0.4)
+    mocha (1.1.0)
+      metaclass (~> 0.0.1)
+    moodle2cc (0.2.10)
+      builder
+      happymapper
+      nokogiri
+      rdiscount
+      rubyzip (>= 1.0.0)
+      thor
+    multi_json (1.8.2)
+    mustache (0.99.5)
+    mysql2 (0.2.18)
+    net-ldap (0.3.1)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (2.9.1)
+    netaddr (1.5.0)
+    nokogiri (1.5.6)
+    oauth-instructure (0.4.10)
+    oj (2.5.5)
+    parallel (0.5.16)
+    pg (0.15.0)
+    polyglot (0.3.5)
+    posix-spawn (0.3.8)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pygments.rb (0.5.4)
+      posix-spawn (~> 0.3.6)
+      yajl-ruby (~> 1.1.0)
+    rack (1.1.3)
+    rack-mini-profiler (0.9.1)
+      rack (>= 1.1.3)
+    rake (10.3.2)
+    ratom-instructure (0.6.9)
+      libxml-ruby (>= 1.1.2)
+    rb-fchange (0.0.6)
+      ffi
+    rb-fsevent (0.9.4)
+    rb-inotify (0.9.5)
+      ffi (>= 0.5.0)
+    rb-kqueue (0.2.3)
+      ffi (>= 0.5.0)
+    rdiscount (1.6.8)
+    rdoc (3.12)
+      json (~> 1.4)
+    recaptcha (0.3.1)
+    redcarpet (3.0.0)
+    redis (3.0.1)
+    redis-scripting (1.0.1)
+      redis (>= 3.0)
+    ritex (1.0.1)
+    rotp (1.6.1)
+    rqrcode (0.4.2)
+    rscribd (1.2.0)
+      mime-types
+    rspec (1.3.2)
+    rspec-rails (1.3.4)
+      rack (>= 1.0.0)
+      rspec (~> 1.3.1)
+    ruby-saml-mod (0.1.29)
+      ffi
+      libxml-ruby (>= 2.3.0)
+    ruby2ruby (2.0.8)
+      ruby_parser (~> 3.1)
+      sexp_processor (~> 4.0)
+    ruby_parser (3.6.1)
+      sexp_processor (~> 4.1)
+    rubycas-client (2.3.9)
+      activesupport
+    rufus-scheduler (2.0.6)
+    safe_yaml (0.9.7)
+    safe_yaml-instructure (0.8.0)
+    sanitize (2.0.3)
+      nokogiri (>= 1.4.4, < 1.6)
+    sass (3.2.18)
+    selenium-webdriver (2.42.0)
+      childprocess (>= 0.5.0)
+      multi_json (~> 1.0)
+      rubyzip (~> 1.0)
+      websocket (~> 1.0.4)
+    sequel (4.5.0)
+    sexp_processor (4.2.1)
+    shackles (1.0.5)
+      activerecord (>= 2.3, < 4.2)
+    simple_uuid (0.4.0)
+    simplecov (0.8.2)
+      docile (~> 1.1.0)
+      multi_json
+      simplecov-html (~> 0.8.0)
+    simplecov-html (0.8.0)
+    simplecov-rcov (0.2.3)
+      simplecov (>= 0.4.1)
+    slop (3.6.0)
+    soap4r-middleware (0.8.3)
+      soap4r-ruby1.9 (= 2.0.0)
+    soap4r-ruby1.9 (2.0.0)
+    sqlite3 (1.3.9)
+    sshkit (1.5.1)
+      colorize
+      net-scp (>= 1.1.2)
+      net-ssh (>= 2.8.0)
+    statsd-ruby (1.0.0)
+    subexec (0.0.4)
+    syck (1.0.3)
+    test-unit (1.2.3)
+      hoe (>= 1.5.1)
+    thin (1.5.1)
+      daemons (>= 1.0.9)
+      eventmachine (>= 0.12.6)
+      rack (>= 1.0.0)
+    thor (0.18.1)
+    thrift (0.8.0)
+    thrift_client (0.8.4)
+      thrift (~> 0.8.0)
+    timecop (0.6.3)
+    treetop (1.4.15)
+      polyglot
+      polyglot (>= 0.3.1)
+    tzinfo (0.3.35)
+    uniform_notifier (1.4.0)
+    useragent (0.4.16)
+    uuid (2.3.2)
+      macaddr (~> 1.0)
+    uuidtools (2.1.4)
+    webmock (1.16.1)
+      addressable (>= 2.2.7)
+      crack (>= 0.3.2)
+    websocket (1.0.7)
+    will_paginate (2.3.15)
+    xml-simple (1.0.12)
+    ya2yaml (0.30)
+    yajl-ruby (1.1.0)
+    yard (0.8.0)
+    yard-appendix (0.1.8)
+      yard (>= 0.8.0)
+    zip-zip (0.2)
+      rubyzip (>= 1.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  active_model_serializers_rails_2.3 (= 0.9.0alpha1)
+  active_polymorph!
+  activesupport-suspend_callbacks!
+  acts_as_list!
+  addressable (= 2.3.5)
+  adheres_to_policy!
+  adobe_connect (= 1.0.0)
+  authlogic (= 2.1.3)
+  autoprefixer-rails (= 1.1.20140512)
+  aws-sdk (= 1.21.0)
+  barby (= 0.5.0)
+  bcrypt-ruby (= 3.0.1)
+  bluecloth (= 2.0.10)
+  bookmarked_collection!
+  builder (= 3.0.0)
+  bullet (= 4.5.0)
+  bundler (>= 1.5.1, <= 1.6.3)
+  byebug (= 3.1.2)
+  canvas_breach_mitigation!
+  canvas_cassandra!
+  canvas_color!
+  canvas_connect (= 0.3.5)
+  canvas_crummy!
+  canvas_ember_url!
+  canvas_ext!
+  canvas_http!
+  canvas_kaltura!
+  canvas_mimetype_fu!
+  canvas_quiz_statistics!
+  canvas_sanitize!
+  canvas_slug!
+  canvas_sort!
+  canvas_statsd!
+  canvas_stringex!
+  canvas_text_helper!
+  canvas_time!
+  canvas_uuid!
+  canvas_webex (= 0.14)
+  capistrano (~> 3.1)
+  capistrano-passenger
+  capistrano-rails (~> 1.1)
+  cassandra-cql (= 1.2.2)!
+  childprocess (= 0.5.0)
+  chunky_png (= 1.3.0)
+  coffee-script (= 2.2.0)
+  coffee-script-source (= 1.6.2)
+  colored (= 1.2)
+  columnize (= 0.8.9)
+  compass (= 0.12.4)
+  crack (= 0.4.1)
+  crocodoc-ruby (= 0.0.1)
+  cssmin (= 1.0.3)
+  daemons (= 1.1.0)
+  debugger (= 1.6.6)
+  diff-lcs (= 1.1.3)
+  docile (= 1.1.3)
+  dress_code (= 1.0.2)
+  encrypted_cookie_store-instructure (= 1.0.6)
+  erubis (= 2.7.0)
+  event_stream!
+  eventmachine (= 1.0.3)
+  execjs (= 1.4.0)
+  facebook!
+  fake_arel (= 1.5.0)
+  fake_rails3_routes (= 1.0.4)
+  ffi (= 1.1.5)
+  ffi-icu (= 0.1.2)
+  folio-pagination-legacy (= 0.0.3)
+  foreigner (= 0.9.2)
+  fssm (= 0.2.10)
+  google_docs!
+  guard (= 1.8.0)
+  hairtrigger (= 0.2.9)
+  handlebars_tasks!
+  happymapper (= 0.4.1)
+  hashdiff (= 0.2.0)
+  hashery (= 1.3.0)
+  hashie (= 2.0.5)
+  highline (= 1.6.1)
+  hoe (= 3.8.1)
+  html_text_helper!
+  i18n (= 0.6.8)
+  i18n_extraction!
+  i18n_tasks!
+  i18nema (= 0.0.7)
+  icalendar (= 1.5.4)
+  iconv (= 1.0.4)
+  incoming_mail_processor!
+  instructure-active_model-better_errors (= 1.6.5.rails2.3)
+  instructure-redis-store (= 1.0.0.2.instructure1)
+  jammit (= 0.6.6)
+  journey (= 1.0.4)
+  jsmin (= 1.0.1)
+  json (= 1.8.1)
+  json_token!
+  letter_opener!
+  libxml-ruby (= 2.6.0)
+  linked_in!
+  listen (~> 1.3)
+  lti_outbound!
+  macaddr (= 1.0.0)
+  mail (= 2.5.4)
+  marginalia (= 1.1.3)
+  metaclass (= 0.0.2)
+  mime-types (= 1.17.2)
+  mini_magick (= 1.3.2)
+  mocha (= 1.1.0)
+  moodle2cc (= 0.2.10)
+  multi_json (= 1.8.2)
+  multipart!
+  mustache (= 0.99.5)
+  mysql2 (= 0.2.18)
+  net-ldap (= 0.3.1)
+  netaddr (= 1.5.0)
+  nokogiri (= 1.5.6)
+  oauth-instructure (= 0.4.10)
+  oj (= 2.5.5)
+  paginated_collection!
+  parallel (= 0.5.16)
+  pg (= 0.15.0)
+  polyglot (= 0.3.5)
+  posix-spawn (= 0.3.8)
+  pygments.rb (= 0.5.4)
+  rack (= 1.1.3)
+  rack-mini-profiler (= 0.9.1)
+  rails!
+  rake (= 10.3.2)
+  ratom-instructure (= 0.6.9)
+  rb-fchange
+  rb-fsevent
+  rb-inotify (~> 0.9.0)
+  rdiscount (= 1.6.8)
+  rdoc (= 3.12)
+  recaptcha (= 0.3.1)
+  redcarpet (= 3.0.0)
+  redis (= 3.0.1)
+  redis-scripting (= 1.0.1)
+  ritex (= 1.0.1)
+  rotp (= 1.6.1)
+  rqrcode (= 0.4.2)
+  rscribd (= 1.2.0)
+  rspec (= 1.3.2)
+  rspec-rails (= 1.3.4)
+  ruby-saml-mod (= 0.1.29)
+  ruby2ruby (= 2.0.8)
+  ruby_parser (= 3.6.1)
+  rubycas-client (= 2.3.9)
+  rubyzip (= 1.1.0)!
+  rufus-scheduler (= 2.0.6)
+  safe_yaml (= 0.9.7)
+  safe_yaml-instructure (= 0.8.0)
+  sanitize (= 2.0.3)
+  sass (= 3.2.18)
+  selenium-webdriver (= 2.42.0)
+  sequel (= 4.5.0)
+  shackles (= 1.0.5)
+  simple_uuid (= 0.4.0)
+  simplecov (= 0.8.2)
+  simplecov-rcov (= 0.2.3)
+  soap4r-middleware (= 0.8.3)
+  soap4r-ruby1.9 (= 2.0.0)
+  sqlite3 (= 1.3.9)
+  subexec (= 0.0.4)
+  syck (= 1.0.3)
+  test-unit (= 1.2.3)
+  thin (= 1.5.1)
+  thor (= 0.18.1)
+  thrift (= 0.8.0)
+  thrift_client (= 0.8.4)
+  timecop (= 0.6.3)
+  treetop (= 1.4.15)
+  twitter!
+  tzinfo (= 0.3.35)
+  uniform_notifier (= 1.4.0)
+  useragent (= 0.4.16)
+  utf8_cleaner!
+  uuid (= 2.3.2)
+  uuidtools (= 2.1.4)
+  webmock (= 1.16.1)
+  websocket (= 1.0.7)
+  will_paginate (= 2.3.15)
+  workflow!
+  xml-simple (= 1.0.12)
+  yajl-ruby (= 1.1.0)
+  yard (= 0.8.0)
+  yard-appendix (>= 0.1.8)
+  zip-zip (= 0.2)


### PR DESCRIPTION
The command: `bundle exec cap staging deploy` was failing with the following.  This is happening because Canvas sets up a trick in Gemfile so that we can alter the actual gems used at runtime by populating the Gemfile.d directory.  However, Capistrano knows nothing about that and tries to release using what is in source control by running `git archive bz-staging | tar -x -C /var/canvas/releases/<someReleaseDate>`.

```
DEBUG[ecd43370] Command: cd /var/canvas/releases/20141113171953 && /usr/bin/env bundle install --binstubs /var/canvas/shared/bin --path /var/canvas/shared/bundle --without development test --deployment --quiet
DEBUG[ecd43370]     The --deployment flag requires a Gemfile.lock. Please make sure you have checked
DEBUG[ecd43370]     your Gemfile.lock into version control before deploying.
cap aborted!
```
