### PR TITLE
Add a Google Analytics tracker 

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -36,5 +36,6 @@
       }
       document.addEventListener('click', _earlyClick);
   </script>
+  <%= render 'shared/google_analytics' %>
 </head>
 <body class="<%= (@body_classes).uniq.join(" ") %>">

--- a/app/views/shared/_google_analytics.html.erb
+++ b/app/views/shared/_google_analytics.html.erb
@@ -1,0 +1,14 @@
+<%# This prevents the tracker from running on non-production environments, like staging %>
+<% if Rails.application.secrets.google_analytics_account %>
+<%= javascript_tag do %>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', '<%=Rails.application.secrets.google_analytics_account%>', 'auto');
+  ga('require', 'displayfeatures');
+  ga('send', 'pageview');
+
+<% end %>
+<% end %>


### PR DESCRIPTION
It only runs if configured in secrets.yml so that we can run it on production only and not have staging and localhost actions mess up the data.
