### PR TITLE
Fix Google Analytics configs to use the old Rails way

### DIFF
--- a/app/views/shared/_google_analytics.html.erb
+++ b/app/views/shared/_google_analytics.html.erb
@@ -1,12 +1,12 @@
 <%# This prevents the tracker from running on non-production environments, like staging %>
-<% if Rails.application.secrets.google_analytics_account %>
+<% if BeyondZConfiguration.google_analytics_account %>
 <%= javascript_tag do %>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-  ga('create', '<%=Rails.application.secrets.google_analytics_account%>', 'auto');
+  ga('create', '<%=BeyondZConfiguration.google_analytics_account%>', 'auto');
   ga('require', 'displayfeatures');
   ga('send', 'pageview');
 

--- a/config/beyondz.yml.example
+++ b/config/beyondz.yml.example
@@ -1,14 +1,20 @@
-test:
-  base_url: https://staging.beyondz.org/
+development:
+  base_url: https://localhost
   change_password_path: /users/edit
   nonexistent_user_path: /users/not_on_lms
 
-development:
+test:
+  base_url: https://test.beyondz.org/
+  change_password_path: /users/edit
+  nonexistent_user_path: /users/not_on_lms
+
+staging:
   base_url: https://staging.beyondz.org/
   change_password_path: /users/edit
   nonexistent_user_path: /users/not_on_lms
 
 production:
-  base_url: https://staging.beyondz.org/
+  google_analytics_account: UA-XXXXXXXX-1
+  base_url: https://www.beyondz.org/
   change_password_path: /users/edit
   nonexistent_user_path: /users/not_on_lms

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -45,7 +45,7 @@ set :deploy_to, '/var/canvas'
 # for core ruby config, like boot.rb when it sets RAILS_ROOT.  You'll get Rack loading
 # errors when it can't find files (e.g. lib/canvas_logger).  This is the reason that
 # configs are copied over in the copy_configs task.
-set :linked_dirs, %w{bin log tmp/pids public/system}
+set :linked_dirs, %w{log tmp/pids public/system}
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }

--- a/config/initializers/beyondz.rb
+++ b/config/initializers/beyondz.rb
@@ -1,9 +1,17 @@
 class BeyondZConfiguration
   @config = (ConfigFile.load("beyondz") || {}).symbolize_keys
 
+  # Returns the URL of the configured public facing beyondz.org server with the
+  # specified path_symbol concatenated.
   def self.url(path_symbol)
     path = @config[path_symbol]
     path = path[1 .. -1] if path.starts_with?('/')
     "#{@config[:base_url]}#{path}"
   end
+
+  # Returns the Google Analytics token if configured or nil if not.  Example token: UA-XXXXXXXX-1 
+  def self.google_analytics_account
+    @config[:google_analytics_account]
+  end
+
 end


### PR DESCRIPTION
Rails.application isn't automatically there for you.  We have to explicitly load configs.

Also, Capistrano was symlinking the bin directory.  This is wrong because bundle install creates them on each deploy.  It also broke the bins after a rollback since the bins aren't maintained on a per release basis.  See deploy.rb for the change.
