### PR TITLE
Change where capistrano deploy installs bins

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -18,6 +18,7 @@ set :group,         'canvasadmin'
 set :bundle_path, "vendor/bundle"
 set :bundle_without, nil
 set :bundle_flags,  ""
+set :bundle_binstubs, nil 
 
 # Default branch is :master
 # ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }.call


### PR DESCRIPTION
It was installing bins to shared/bins which is inconsistent on rollback and doesn't serve any purpose anyway since we install locally for each release to vendor/bundle (to match the Canvas Production Start guide).  This change is to also install the bins locally per release so that after rollback, running something like bin/rails should work.
