### PR TITLE
Add the userId as a custom Google Analytics dimension 

### DIFF
--- a/app/views/shared/_google_analytics.html.erb
+++ b/app/views/shared/_google_analytics.html.erb
@@ -11,6 +11,12 @@
   <% else %>
     ga('create', '<%=BeyondZConfiguration.google_analytics_account%>', 'auto');
   <% end %>
+
+  <%# Setting the Google Analytics recognized userId above enables cross device reports, but doesn't actually expose the id itself.  
+      We want to actually see the id so that we can cross reference usage patterns back to the actual person on our end (even 
+      the id itself is not personably identifiable info and thus doesn't violote GA's terms of service).%>
+  ga('set', 'dimension1', '<%= @current_user.id %>');
+  
   ga('require', 'displayfeatures');
   ga('send', 'pageview');
 


### PR DESCRIPTION
Once this is enabled by logging into Google Analytics web dashboard and adding it, we can setup custom usage reports that tie it back to the user on our end.  Here is how I had to add the Custom Dimension in the GA Admin dashboard: https://support.google.com/analytics/answer/2709829 
