### PR TITLE
Configure capistrano deploys to point to staging clone

### DIFF
--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -8,7 +8,10 @@ role :app, %w{deploy@stagingportal.beyondz.org}
 role :web, %w{deploy@stagingportal.beyondz.org}
 role :db,  %w{deploy@stagingportal.beyondz.org}
 
-set :branch, 'bz-staging'
+# TODO: this branch is temporary while we test the upstream changes pulled in
+# on a Staging clone.  Once everything is good and we want to push this, we need
+# to change this to the real bz-staging branch (and get this branch merged into there)
+set :branch, 'bz-upstream-updates'
 
 
 # Extended Server Syntax


### PR DESCRIPTION
We want to test the upstream changes pulled from Instructure on a clone of the staging server.  Once it's validated, we'll merge this branch back to staging, undo this commit, and deploy to the actual staging instance.
