### PR TITLE
Make code upgrades work by enabling db:migrate on a capistrano deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -73,7 +73,7 @@ end
 Rake::Task["deploy:rollback_assets"].clear_actions
 
 # Disable for now until we get the basic Cap deploy and rollback going for code and can really test this.
-Rake::Task["deploy:migrate"].clear_actions
+#Rake::Task["deploy:migrate"].clear_actions
 
 Rake::Task["deploy:restart"].clear_actions
 
@@ -110,10 +110,10 @@ namespace :deploy do
 
   before :updated, :clone_qtimigrationtool
 
-  desc "Migrate database"
-  task :migrate do
-    # TODO: need to get this working, but for now we're just focusing on getting a code deploy and rollback flow going
-  end
+  #desc "Migrate database"
+  #task :migrate do
+  #  # TODO: need to get this working, but for now we're just focusing on getting a code deploy and rollback flow going
+  #end
 
   desc "Compile static assets"
   task :compile_assets => :set_compile_assets_vars do
@@ -206,7 +206,7 @@ namespace :deploy do
       execute :sudo, 'chown -R', "#{group}:#{group}", "#{release_path}"
       within release_path do
         execute :sudo, 'chown', "#{user}", "config/*", "Gemfile.lock", "config.ru"
-        execute :sudo, 'chmod 400', "config/*.yml"
+        execute :sudo, 'chmod 440', "config/*.yml"
       end
     end
   end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -205,7 +205,7 @@ namespace :deploy do
       group = fetch :group
       execute :sudo, 'chown -R', "#{group}:#{group}", "#{release_path}"
       within release_path do
-        execute :sudo, 'chown', "#{user}", "config/*", "Gemfile.lock", "config.ru"
+        execute :sudo, 'chown', "#{user}", "config/*", "Gemfile.lock", "config.ru", "tmp/"
         execute :sudo, 'chmod 440', "config/*.yml"
       end
     end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -216,7 +216,7 @@ namespace :deploy do
   desc 'Restart application'
   task :restart do
     on roles(:app) do
-      execute :sudo, 'chmod g+w', release_path.join('tmp') # No clue why, but on prod the releases/XXXXX/tmp dir is created but not group writeable.
+      execute :sudo, 'chmod -R g+w', release_path.join('tmp') # No clue why, but on prod the releases/XXXXX/tmp dir is created but not group writeable.
       execute :touch, release_path.join('tmp/restart.txt')
     end
   end


### PR DESCRIPTION
Also, sneak in some permissions fixes.
