### PR TITLE
User Settings and Bio was breaking. Hack fix. 

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -2,7 +2,7 @@
   @locale = raw I18n.locale.to_json
   @body_classes ||= []
   @body_classes << "context-#{@context.asset_string}" if @context
-  if @current_user && @context && !can_do(@context, @current_user, :manage)
+  if @current_user && @context && @context.respond_to?(:grants_any_right?) && !can_do(@context, @current_user, :manage)
     @body_classes << "student-logged-in"
   end
   yield :pre_html


### PR DESCRIPTION
In the updated canvas code, I was getting an error when clicking on Settings or their Bio page b/c the `context` object didn't have a `grants_any_right?` method.  This introduces a bug b/c the student-logged-in CSS class will be missing there.
