### PR TITLE
Add way to create users from api and not have them validate email.

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1223,7 +1223,7 @@ class UsersController < ApplicationController
     end
     @user.name ||= params[:pseudonym][:unique_id]
     unless @user.registered?
-      @user.workflow_state = if require_password
+      @user.workflow_state = if require_password || skip_confirmation
         # no email confirmation required (self_enrollment_code and password
         # validations will ensure everything is legit)
         'registered'


### PR DESCRIPTION
This used to work in the old code and I can't figure out how to skip email confirmation when creating users from the api in the current code.  The communication_chanell[skip_confirmation] parameter seems like it should do it, but it doesn't.  I'm going to make it work the way the documentation seems to indicate and cross my fingers that I don't introduce a bug for some use case I'm unfamiliar with.
