### PR TITLE
filter bug fixes - jquery was responsible

### DIFF
--- a/app/coffeescripts/str/convertApiUserContent.coffee
+++ b/app/coffeescripts/str/convertApiUserContent.coffee
@@ -7,7 +7,9 @@ define [
   # use this method to process any user content fields returned in api responses
   # this is important to handle object/embed tags safely, and to properly display audio/video tags
   convertApiUserContent = (html, options = {}) ->
-    $dummy = $('<div />').html(html)
+    $dummy = document.createElement('div')
+    $dummy.innerHTML = html
+    $dummy = $($dummy)
     # finds any <video/audio class="instructure_inline_media_comment"> and turns them into media comment thumbnails
     $dummy.find('video.instructure_inline_media_comment,audio.instructure_inline_media_comment').replaceWith ->
       $node = $("<a id='media_comment_#{htmlEscape($(this).data('media_comment_id'))}'

--- a/config/beyondz.yml.example
+++ b/config/beyondz.yml.example
@@ -3,21 +3,21 @@ development:
   change_password_path: /users/edit
   nonexistent_user_path: /users/not_on_lms
   bitly_access_token: 12345689assdfe
-  unrestricted_html_users: [1]
+  unrestricted_html_users: [1, 2]
 
 test:
   base_url: https://test.beyondz.org/
   change_password_path: /users/edit
   nonexistent_user_path: /users/not_on_lms
   bitly_access_token: 12345689assdfe
-  unrestricted_html_users: [1]
+  unrestricted_html_users: [1, 2]
 
 staging:
   base_url: https://staging.beyondz.org/
   change_password_path: /users/edit
   nonexistent_user_path: /users/not_on_lms
   bitly_access_token: 12345689assdfe
-  unrestricted_html_users: [1]
+  unrestricted_html_users: [1, 2]
 
 production:
   google_analytics_account: UA-XXXXXXXX-1
@@ -25,4 +25,4 @@ production:
   change_password_path: /users/edit
   nonexistent_user_path: /users/not_on_lms
   bitly_access_token: 12345689assdfe
-  unrestricted_html_users: [1]
+  unrestricted_html_users: [1, 2]


### PR DESCRIPTION
Turns out the jQuery .html filters the script and they used it in one of these things. Switching to the standard innerHTML fixed it. Since the other data is still filtered on the server, this shouldn't introduce any problem - that html call seems to have no intention to filter scripts, it was just to get the data into the dummy element.

I also updated the example to show the significant whitespace in yaml so filtering option works for multiple users too.

A little more context, for a whitelisted set of users we are allowing inline CSS and JS when editing content.  This pull fixes a behavior where adding inline `script` elements was getting stripped on Save.
