### PR TITLE
timezone warning (needs css)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -133,6 +133,7 @@ class ApplicationController < ActionController::Base
     @js_env[:context_asset_string] = @context.try(:asset_string) if !@js_env[:context_asset_string]
     @js_env[:ping_url] = polymorphic_url([:api_v1, @context, :ping]) if @context.is_a?(Course)
     @js_env[:TIMEZONE] = Time.zone.tzinfo.identifier if !@js_env[:TIMEZONE]
+    @js_env[:TIMEZONE_OFFSET] = Time.zone.utc_offset if !@js_env[:TIMEZONE_OFFSET]
     @js_env[:CONTEXT_TIMEZONE] = @context.time_zone.tzinfo.identifier if !@js_env[:CONTEXT_TIMEZONE] && @context.respond_to?(:time_zone) && @context.time_zone.present?
     @js_env[:LOCALE] = I18n.qualified_locale if !@js_env[:LOCALE]
     @js_env[:TOURS] = tours_to_run

--- a/app/views/layouts/_foot.html.erb
+++ b/app/views/layouts/_foot.html.erb
@@ -45,7 +45,7 @@
 </script>
 
 <div id="bz-tz-warning" style="display: none;">
-  Please ensure your <a href="/profile/settings">user settings</a> shows the right time zone!
+  We noticed that your current timezone doesn't match your <a href="/profile/settings">settings</a>. Consider changing your <a href="/profile/settings">settings</a> so your due dates show the right time!
   <button type="button" onclick="localStorage.skipTzWarning = 'yes'; this.parentNode.style.display = 'none';">Don't tell me again</button>
 </div>
 

--- a/app/views/layouts/_foot.html.erb
+++ b/app/views/layouts/_foot.html.erb
@@ -43,3 +43,22 @@
   check();
 }).call(this);
 </script>
+
+<div id="bz-tz-warning" style="display: none;">
+  Please ensure your <a href="/profile/settings">user settings</a> shows the right time zone!
+  <button type="button" onclick="localStorage.skipTzWarning = 'yes'; this.parentNode.style.display = 'none';">Don't tell me again</button>
+</div>
+
+<script>
+  if(ENV["TIMEZONE_OFFSET"] && localStorage.skipTzWarning != "yes") {
+    // JS gives minutes, Rails gives seconds, and they come from other directions
+    // so the negative and divide make them match up
+    var rails_tz = -ENV["TIMEZONE_OFFSET"] / 60;
+    var offset = new Date().getTimezoneOffset();
+    if(rails_tz != offset) {
+      var t = document.getElementById("bz-tz-warning");
+      if(t)
+        t.style.display = "";
+    }
+  }
+</script>


### PR DESCRIPTION
If the user machine's timezone (via JS) doesn't match the user account's timezone (via Rails), it will show a warning. It can be hidden with a button that stores a local setting so it doesn't show again on this computer.
