### PR TITLE
Don't email real people on dev/staging in invites

### DIFF
--- a/app/models/calendar_event.rb
+++ b/app/models/calendar_event.rb
@@ -90,12 +90,14 @@ class CalendarEvent < ActiveRecord::Base
 
     if context_type == 'CourseSection'
       CourseSection.find(context_id).students.all.each do |user|
+        next if !BeyondZConfiguration.safe_to_email? user.email
         event['attendees'] << { email: user.email }
       end
     end
 
     if context_type == 'Course'
       Course.find(context_id).students.all.each do |user|
+        next if !BeyondZConfiguration.safe_to_email? user.email
         event['attendees'] << { email: user.email }
       end
     end

--- a/config/initializers/beyondz.rb
+++ b/config/initializers/beyondz.rb
@@ -17,4 +17,13 @@ class BeyondZConfiguration
   def self.bitly_access_token
     @config[:bitly_access_token]
   end
+
+  def self.production?
+    @config[:base_url] == 'https://join.bebraven.org/'
+  end
+
+  def self.safe_to_email?(email)
+    # If we are on production, we can email anybody, but on staging or dev,
+    # we should only email staff members or Adam's local domain test accounts.
+    self.production? || email.include? '@bebraven.org' || email.include? '@arsdnet.net'
 end

--- a/config/initializers/beyondz.rb
+++ b/config/initializers/beyondz.rb
@@ -25,7 +25,8 @@ class BeyondZConfiguration
   def self.safe_to_email?(email)
     # If we are on production, we can email anybody, but on staging or dev,
     # we should only email staff members or Adam's local domain test accounts.
-    self.production? || email.include? '@bebraven.org' || email.include? '@arsdnet.net'
+    return self.production? || email.include?('@bebraven.org') || email.include?('@arsdnet.net')
+  end
 
   # Returns the URL of teh Braven Help site.  e.g. https://help.bebraven.org
   def self.help_url

--- a/config/initializers/beyondz.rb
+++ b/config/initializers/beyondz.rb
@@ -19,6 +19,9 @@ class BeyondZConfiguration
   end
 
   def self.production?
+    # This is the value of a setting we set on production
+    # remember to edit this if we ever rebrand again so this
+    # setting always matches
     @config[:base_url] == 'https://join.bebraven.org/'
   end
 


### PR DESCRIPTION
Since it is done via an external service (gcal) it bypasses our server-level email filter so we want to do it here before passing to their api too.
