### PR TITLE
fix for missing TOC on some pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -133,7 +133,7 @@ class ApplicationController < ActionController::Base
     @js_env[:context_asset_string] = @context.try(:asset_string) if !@js_env[:context_asset_string]
     @js_env[:ping_url] = polymorphic_url([:api_v1, @context, :ping]) if @context.is_a?(Course)
     @js_env[:TIMEZONE] = Time.zone.tzinfo.identifier if !@js_env[:TIMEZONE]
-    @js_env[:TIMEZONE_OFFSET] = Time.zone.utc_offset if !@js_env[:TIMEZONE_OFFSET]
+    @js_env[:TIMEZONE_OFFSET] = Time.zone.now.utc_offset if !@js_env[:TIMEZONE_OFFSET]
     @js_env[:CONTEXT_TIMEZONE] = @context.time_zone.tzinfo.identifier if !@js_env[:CONTEXT_TIMEZONE] && @context.respond_to?(:time_zone) && @context.time_zone.present?
     @js_env[:LOCALE] = I18n.qualified_locale if !@js_env[:LOCALE]
     @js_env[:TOURS] = tours_to_run


### PR DESCRIPTION
The module_item_id URL param was sometimes missing. This looks it up from context in those cases so it works anyway.
