### PR TITLE
New debug and the fruits of it - gcal sync fixes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,6 +19,8 @@
 # Filters added to this controller apply to all controllers in the application.
 # Likewise, all the methods added will be available for all controllers.
 
+require 'bz_debug'
+
 class ApplicationController < ActionController::Base
   def self.promote_view_path(path)
     self.view_paths = self.view_paths.to_ary.reject{ |p| p.to_s == path }
@@ -1027,6 +1029,13 @@ class ApplicationController < ActionController::Base
       message << exception.annoted_source_code.to_s if exception.respond_to?(:annoted_source_code)
       message << "  " << exception.backtrace.join("\n  ")
       logger.fatal("#{message}\n\n")
+
+      # I want just a fraction of the info printed to my custom debug
+      # because I typically only care about our own modifications
+      BZDebug.log("#{exception.class} (#{exception.message}):")
+      BZDebug.log("  " + exception.backtrace[0])
+      BZDebug.log("  " + exception.backtrace[1])
+      BZDebug.log("  " + exception.backtrace[2])
     end
 
     if config.consider_all_requests_local

--- a/lib/bz_debug.rb
+++ b/lib/bz_debug.rb
@@ -1,0 +1,32 @@
+# The purpose of this file is to ease debugging and figuring out
+# just what is going on. It defines a global function which will
+# write out information to a *separate* log file which I can inspect
+# more easily than the main log (which is sometimes useful so I don't
+# want to turn it off, but is also too hard to use for easy things)
+
+class BZDebug
+
+  @@bz_dont_attempt_logging = false
+  @@bz_debug_file = nil
+
+  def self.setup
+    return if @@bz_dont_attempt_logging
+    begin
+      @@bz_debug_file = File.new("bz-debug.log", "a")
+    rescue
+      # if any attempt at logging fails, just give up entirely so it
+      # doesn't spam error reports about that too
+      @@bz_dont_attempt_logging = true
+    end
+  end
+  def self.log(what)
+    BZDebug.setup if @@bz_debug_file.nil?
+    return if @@bz_dont_attempt_logging
+    begin
+      @@bz_debug_file.puts(what.inspect)
+      @@bz_debug_file.flush
+    rescue
+      @@bz_dont_attempt_logging = true
+    end
+  end
+end


### PR DESCRIPTION
I wrote a little debug helper lib to do a separate log that I can actually read and write to easily and was able to trace, in real time, what calls actually happened and when.

Turns out sync was called twice on edit save, once on edit more options view (!), and once AFTER the kill event. So that's why it would delete on gcal then recreate and why the other things were kinda slow.

This makes things sane. I want to leave the logging on for the push too, at least to staging - it shouldn't affect speed of running much and will give us useful info to retrace the steps to debug this more rapidly.

Even if we remove the log calls eventually, I want to keep the framework in here for future use. I think I got more done in the one hour after writing it than I did the last two days working the other way.
