### PR TITLE
redirect dash to course home if in only one course

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -484,6 +484,10 @@ class UsersController < ApplicationController
     @announcements = AccountNotification.for_user_and_account(@current_user, @domain_root_account)
     @pending_invitations = @current_user.cached_current_enrollments(:include_enrollment_uuid => session[:enrollment_uuid], :preload_courses => true).select { |e| e.invited? }
     @stream_items = @current_user.try(:cached_recent_stream_items) || []
+
+    if @current_user.enrollments.active.count == 1
+      redirect_to "/courses/#{@current_user.enrollments.active.first.course.id}"
+    end
   end
 
   def cached_upcoming_events(user)


### PR DESCRIPTION
Instead of going to last page, it goes to course home because the dynamic syllabus is going to become a good place always soon, and even now, it gives a good introduction page, a good resume page, and works in all cases - including original login and clicking the logo in the upper left (which I wanted to be consistent... and not just go back to where you were because that would be an endless loop).
