### PR TITLE
disappearing textarea bug fix

### DIFF
--- a/public/javascripts/tinymce.config.js
+++ b/public/javascripts/tinymce.config.js
@@ -100,7 +100,7 @@ define([], function(){
       extended_valid_elements: "*[*]",
       valid_children: "+body[style|script|svg|textarea|img],+p[textarea|input]",
 
-      non_empty_elements: "td th iframe video audio object script a i area base basefont br col frame hr img input isindex link meta param embed source wbr track",
+      non_empty_elements: "textarea td th iframe video audio object script a i area base basefont br col frame hr img input isindex link meta param embed source wbr track",
       content_css: window.ENV.url_to_what_gets_loaded_inside_the_tinymce_editor_css + "," + window.bz_custom_css_url + ",/bz_editor.css",
       browser_spellcheck: true
     };


### PR DESCRIPTION
Empty textareas were being removed by the rich text editor because of this config bug.