### PR TITLE
npm shrinkwrap skipped dependencies.  adding them in manually

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7,6 +7,16 @@
       "from": "https://registry.npmjs.org/brandable_css/-/brandable_css-0.0.62.tgz",
       "resolved": "https://registry.npmjs.org/brandable_css/-/brandable_css-0.0.62.tgz",
       "dependencies": {
+        "autoprefixer": {
+          "version": "6.3.6",
+          "from": "autoprefixer>=6.3.6 <7.0.0",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.3.6.tgz"
+        },
+        "aws-sdk": {
+          "version": "2.3.3",
+          "from": "aws-sdk>=2.3.3 <3.0.0",
+          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.3.3.tgz"
+        },
         "babel-cli": {
           "version": "6.18.0",
           "from": "babel-cli@>=6.7.5 <7.0.0",
@@ -19,15 +29,75 @@
             }
           }
         },
+        "babel-polyfill": {
+          "version": "6.7.4",
+          "from": "babel-polyfill>=6.7.4 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.7.4.tgz"
+        },
+        "babel-preset-es2015": {
+          "version": "6.6.0",
+          "from": "babel-preset-es2015>=6.6.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.6.0.tgz"
+        },
+        "babel-preset-stage-2": {
+          "version": "6.5.0",
+          "from": "babel-preset-stage-2>=6.5.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.5.0.tgz"
+        },
+        "bluebird": {
+          "version": "3.3.5",
+          "from": "bluebird>=3.3.5 <4.0.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.5.tgz"
+        },
+        "bluebird-retry": {
+          "version": "0.6.0",
+          "from": "bluebird-retry>=0.6.0 <1.0.0",
+          "resolved": "https://registry.npmjs.org/bluebird-retry/-/bluebird-retry-0.6.0.tgz"
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "from": "chalk>=1.1.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+        },
+        "chokidar": {
+          "version": "1.4.3",
+          "from": "chokidar>=1.4.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.3.tgz"
+        },
+        "commander": {
+          "version": "2.9.0",
+          "from": "commander>=2.9.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+        },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug>=2.2.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
+        "fs-extra-promise": {
+          "version": "0.3.1",
+          "from": "fs-extra-promise>=0.3.1 <1.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra-promise/-/fs-extra-promise-0.3.1.tgz"
+        },
         "glob": {
           "version": "7.1.1",
           "from": "glob@>=7.0.3 <8.0.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
         },
+        "js-yaml": {
+          "version": "3.5.5",
+          "from": "js-yaml>=3.5.5 <4.0.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz"
+        },
         "lodash": {
           "version": "4.17.4",
           "from": "lodash@>=4.11.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+        },
+        "node-sass": {
+          "version": "3.4.2",
+          "from": "node-sass>=3.4.2 <4.0.0",
+          "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.4.2.tgz"
         },
         "node-zopfli": {
           "version": "1.4.0",
@@ -167,6 +237,21 @@
               }
             }
           }
+        },
+        "postcss": {
+          "version": "5.0.19",
+          "from": "postcss>=5.0.19 <6.0.0",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.19.tgz"
+        },
+        "postcss-url": {
+          "version": "5.1.1",
+          "from": "postcss-url>=5.1.1 <6.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-url/-/postcss-url-5.1.1.tgz"
+        },
+        "rev-hash": {
+          "version": "1.0.0",
+          "from": "rev-hash>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/rev-hash/-/rev-hash-1.0.0.tgz"
         }
       }
     },


### PR DESCRIPTION
only did this for brandable_css.  may have to do babel-core after