### PR TITLE
Add a standalone page to Authorize LinkedIn access

### DIFF
--- a/app/controllers/bz_controller.rb
+++ b/app/controllers/bz_controller.rb
@@ -286,6 +286,11 @@ class BzController < ApplicationController
     end
   end
 
+  # Renders a view to authorize access to LinkedIn regardless of what course you are enrolled in.
+  def linked_in_auth
+    @host_url = "#{request.protocol}#{request.host_with_port}"
+  end
+
   def linked_in_export
     # renders a view to fetch the email address
     @email = @current_user.email

--- a/app/views/bz/linked_in_auth.html.erb
+++ b/app/views/bz/linked_in_auth.html.erb
@@ -1,0 +1,14 @@
+<div class="show-content" style="margin-top: 30px">
+  <p>
+  Braven has a partnership with LinkedIn to help you build your professional network and to stay up to date on your accomplishments.
+  </p>
+  <p>
+  In order for us to do that, <strong>please click the button below</strong> to authorize access your LinkedIn data.
+  </p>
+  <p>
+  <br />
+  <a class="btn btn-small" style="margin-left: 20px" href="/oauth?service=linked_in&amp;return_to=<%= @host_url %>%2Fbz%2Flinked_in_auth">
+    <img src="/dist/images/linked_in_icon-760b214e84.png" alt="Authorize LinkedIn Access">&nbsp;AUTHORIZE ACCESS TO LINKEDIN
+  </a>
+  </p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ CanvasRails::Application.routes.draw do
   get 'bz/retained_data_stats' => 'bz#retained_data_stats'
   get 'bz/retained_data_export' => 'bz#retained_data_export'
 
+  get 'bz/linked_in_auth' => 'bz#linked_in_auth'
   get 'bz/linked_in_export' => 'bz#linked_in_export'
   post 'bz/linked_in_export' => 'bz#do_linked_in_export'
   get 'bz/linked_in_export_oauth_success' => 'bz#linked_in_export_oauth_success'


### PR DESCRIPTION
This is  so we can email people without having to get them in the right course.