### PR TITLE
Replace all links in pages and assignments within the Content Library

### DIFF
--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -34,6 +34,7 @@ class WikiPage < ActiveRecord::Base
   include Submittable
 
   include SearchTermHelper
+  include ContentLibraryHelper
 
   after_update :post_to_pandapub_when_revised
 
@@ -47,7 +48,15 @@ class WikiPage < ActiveRecord::Base
       end
     elsif self.body_changed?
       WikiPage.where(:clone_of_id => id).each do |page|
-        page.body = body
+        # Look for links to other pages / assignments in the Content Library and update those
+        # have placeholders that Javascript can replace with the current course ID on load.
+        page.body = replace_content_library_links_with_local_link_placeholders(body)
+        # Note: technically we could find the course ID to actually fix up the links using the following code,
+        # but we can't do the same when first creating a wiki page from content library in the
+        # clone_from_master_bank method, so for consistency's sake we do the same thing as it does 
+        #tag = ContentTag.where(:content_id => page.id, :content_type => 'WikiPage').first
+        #local_course_id = tag.context_id
+
         # Syncing titles changes the page URL which has a
         # major risk of breaking links in the courses. I
         # am thus going to leave that manual - adr
@@ -62,8 +71,13 @@ class WikiPage < ActiveRecord::Base
   def clone_from_master_bank
     if self.clone_of_id_changed? && !self.clone_of_id.nil?
       master = WikiPage.find(self.clone_of_id)
-      self.body = master.body
-      # see above
+      # Look for links to other pages / assignments in the Content Library and update those
+      # to have placeholders that Javascript can replace with the current course ID on load.
+      # NOTE: can't just straight up fix the links here b/c there is no way to get the course ID
+      # from a brand new wiki page.  The courseId isn't associted with it until after ALL saves
+      # happen and the ContentTag is created for this new page
+      self.body = replace_content_library_links_with_local_link_placeholders(master.body)
+       # see above
       # self.title = master.title
     end
   end

--- a/lib/content_library_helper.rb
+++ b/lib/content_library_helper.rb
@@ -1,0 +1,35 @@
+#
+# Helper class used for Content Library (e.g. Course ID = 1) logic in the models.
+#
+module ContentLibraryHelper
+
+  # Takes the HTML for a page and inserts a LOCAL_COURSE_ID_TOKEN placeholder everywhere
+  # that a link to another page or assignment in the Content Library is found so that
+  # Javascript can replace the placeholders at load time.  Also, adds a "bz-replace-course-token" CSS class
+  # so the JS can be extra defensive when looking for where to replace.
+  # NOTE:  Can't just set the course IDs directly b/c sometimes we're creating a new wiki page from the
+  # Content Library and there is no way to get the Course ID before it's been fully saved and has a ContentTag associated with it.
+  def replace_content_library_links_with_local_link_placeholders(html_body)
+    doc = Nokogiri::HTML(html_body)
+    links = doc.css('a')
+    links.each do |link|
+      url = link.attribute('href').to_s
+      next if url.match(/\/courses\/1\/files/) # Don't adjust links to download files. We expose them to all courses and can just exist in the Content Library
+      if (url.match(/\/courses\/1\//))
+        replaceUrl = url.gsub(/\/courses\/1/, "/courses/LOCAL_COURSE_ID_TOKEN")
+        Rails.logger.debug("### replace_content_library_links_with_local_links: replacing Content Library Course ID with LOCAL_COURSE_ID_TOKEN for: replaceUrl = #{replaceUrl}")
+        link['href'] = replaceUrl
+        link['class'] ||= "" # handles appending to existing CSS classes
+        link['class'] = link['class'] << " bz-replace-course-token"
+        dataApiEndpoint = link.attribute('data-api-endpoint').to_s
+        if (!dataApiEndpoint.blank?)
+          dataApiEndpointReplace = dataApiEndpoint.gsub(/\/courses\/1/, "/courses/LOCAL_COURSE_ID_TOKEN")
+          link['data-api-endpoint'] = dataApiEndpointReplace
+          Rails.logger.debug("### replace_content_library_links_with_local_links: replacing Content Library Course ID with LOCAL_COURSE_ID_TOKEN for: dataApiEndpointReplace = #{dataApiEndpointReplace}")
+        end
+      end
+    end
+    doc.to_html
+  end
+
+end

--- a/lib/content_library_helper.rb
+++ b/lib/content_library_helper.rb
@@ -5,7 +5,7 @@ module ContentLibraryHelper
 
   # Takes the HTML for a page and inserts a LOCAL_COURSE_ID_TOKEN placeholder everywhere
   # that a link to another page or assignment in the Content Library is found so that
-  # Javascript can replace the placeholders at load time.  Also, adds a "bz-replace-course-token" CSS class
+  # Javascript can replace the placeholders at load time.  Also, adds a "bz-ajax-replace" CSS class
   # so the JS can be extra defensive when looking for where to replace.
   # NOTE:  Can't just set the course IDs directly b/c sometimes we're creating a new wiki page from the
   # Content Library and there is no way to get the Course ID before it's been fully saved and has a ContentTag associated with it.
@@ -20,7 +20,7 @@ module ContentLibraryHelper
         Rails.logger.debug("### replace_content_library_links_with_local_links: replacing Content Library Course ID with LOCAL_COURSE_ID_TOKEN for: replaceUrl = #{replaceUrl}")
         link['href'] = replaceUrl
         link['class'] ||= "" # handles appending to existing CSS classes
-        link['class'] = link['class'] << " bz-replace-course-token"
+        link['class'] = link['class'] << " bz-ajax-replace"
         dataApiEndpoint = link.attribute('data-api-endpoint').to_s
         if (!dataApiEndpoint.blank?)
           dataApiEndpointReplace = dataApiEndpoint.gsub(/\/courses\/1/, "/courses/LOCAL_COURSE_ID_TOKEN")


### PR DESCRIPTION
Make them have placeholders for Javascript to replace with the local course id.