### PR TITLE
Fix issue where inline rubrics and file links where sometimes breaking

### DIFF
--- a/lib/copy_authorized_links.rb
+++ b/lib/copy_authorized_links.rb
@@ -56,6 +56,14 @@ module CopyAuthorizedLinks
     end
     
     def copy_authorized_links_to_context
+
+      # When this runs while we're trying to set the linked local courses to the
+      # updated Content Library body, if the page is owned by a user it can sometimes
+      # adjust the local links to things like inline rubrics and files to point at the
+      # local course instead of at the Content Library, so we're disabling this until something
+      # else breaks!
+      return if @content_library_sync
+
       block = self.class.copy_authorized_links_block rescue nil
       columns = (self.class.copy_authorized_links_columns || []).compact
       columns.each do |column|


### PR DESCRIPTION
This happened when the Content Library was updated and the wiki page in one of the linked courses was owned by a user (eg. had a user_id set).  Some logic would run to copy over links and it would adjust those that were supposed to point at the Content LIbrary files, rubrics, etc to point at a non-existant one if the local course.  So, while updating the linked course pages and assignments, short circuit this logic until we notice that it breaks something else down the road!