### PR TITLE
up max for more efficient api batch stuff

### DIFF
--- a/lib/api.rb
+++ b/lib/api.rb
@@ -261,7 +261,7 @@ module Api
   end
 
   def self.max_per_page
-    Setting.get('api_max_per_page', '50').to_i
+    Setting.get('api_max_per_page', '500').to_i
   end
 
   def self.per_page


### PR DESCRIPTION
If I'm right then this, combined with my PR for the join server, will take events loading down from 24 distinct http requests down to just one. Might even help on Canvas itself, if they set the parameter.