### PR TITLE
updatable magic field global export for external api analysis

### DIFF
--- a/app/controllers/bz_controller.rb
+++ b/app/controllers/bz_controller.rb
@@ -165,6 +165,36 @@ class BzController < ApplicationController
     end
   end
 
+  def magic_field_dump
+    access_token = AccessToken.authenticate(params[:access_token])
+    if access_token.nil?
+      render :json => "Access denied"
+      return
+    end
+
+    requesting_user = access_token.user
+    # we should prolly allow designer accounts to access too, but
+    # for now i just want to use the admin access token for myself
+    if requesting_user.id != 1
+      render :json => "Not admin"
+      return
+    end
+
+    result = RetainedData.where("updated_at > to_timestamp(?)", params[:since])
+    data = []
+    result.all.each do |res|
+      obj = {}
+      obj["created_at"] = res.created_at
+      obj["updated_at"] = res.updated_at
+      obj["name"] = res.name
+      obj["value"] = res.value
+      obj["path"] = res.path
+      obj["user_id"] = res.user_id
+      data << obj
+    end
+    render :json => data
+  end
+
   def user_retained_data
     result = RetainedData.where(:user_id => @current_user.id, :name => params[:name])
     data = ''

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ CanvasRails::Application.routes.draw do
 
   get 'bz/retained_data_stats' => 'bz#retained_data_stats'
   get 'bz/retained_data_export' => 'bz#retained_data_export'
+  get 'bz/magic_field_dump' => 'bz#magic_field_dump'
 
   get 'bz/user_linkedin_url' => 'bz#user_linkedin_url'
 


### PR DESCRIPTION
This gives an API hook for admins to get an update of magic field changes. Means we can keep an outside list up to date too (rather than doing full export every time), with history of when it was modified. Means easier analysis of student use of magic fields from things like my new editor (which can suggest things like a regex for right answer checking)