### PR TITLE
solve the mastery checkbox debacle (hopefully) by making it give posi…

### DIFF
--- a/lib/bz_grading.rb
+++ b/lib/bz_grading.rb
@@ -343,6 +343,13 @@ class BZGrading
       end
     end
 
+    if value.nil? && !answer.nil? && answer == '' && field_type == 'checkbox'
+      # the unanswered master checkbox is correct - give them points for that!
+      response_object["points_reason"] = "mastery"
+      response_object["points_amount"] = original_step
+      response_object["points_changed"] = true
+    end
+
 
     response_object["points_reason_english"] = case response_object["points_reason"]
       when 'wrong'


### PR DESCRIPTION
…tive points... so if they never click it, they are right. if we are calculating the whole thing from scratch, making them positive will get us to teh right point from a zero start. if they click it while doing incremental scoring, that is still a special case, but a simpler special case.