### PR TITLE
Make Help tab button URL completely configurable

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -202,7 +202,7 @@
   <%= render :partial => 'layouts/foot', :locals => { :include_common_bundle => true } %>
   <% if BeyondZConfiguration.help_url %> 
   <div id="bz-help-button">
-    <a target="_BLANK" href="<%= BeyondZConfiguration.help_url %>/questions/ask/">Help</a>
+    <a target="_BLANK" href="<%= BeyondZConfiguration.help_url %>">Help</a>
   </div>
   <% end %>
 </div> <!-- #application -->


### PR DESCRIPTION
BeyondZConfiguration.help_url used to be the root of the URL and the path was hardcoded. Now nothing is hardcoded and the config needs to be updated to the full path.