### PR TITLE
Ignore cloud9 files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ docker-compose.override.yml
 
 # ignore tmp files from emacs
 *~
+
+# ignore cloud9 files
+.c9/*


### PR DESCRIPTION
Since brose and hcli are working in a dev environment in AWS, we had to use cloud9 for our IDE. This commit ignores the installed cloud9 files.