### PR TITLE
Fix Qualtrics embedded data and syncing contacts to Mailing Lists

### DIFF
--- a/app/controllers/bz_controller.rb
+++ b/app/controllers/bz_controller.rb
@@ -1916,8 +1916,6 @@ class BzController < ApplicationController
   end
 
   # Gets an object populated with the response to: https://api.qualtrics.com/reference#list-mailing-lists-1
-  #
-  # Note: Sometimes the response isn't populated even though it says 200 OK. Just try a couple times.
   def fetch_qualtrics_mailing_lists(http)
     url = URI.parse("https://#{BeyondZConfiguration.qualtrics_host}/API/v3/mailinglists")
     headers = {}

--- a/app/controllers/bz_controller.rb
+++ b/app/controllers/bz_controller.rb
@@ -1780,39 +1780,68 @@ class BzController < ApplicationController
       return
     end
 
-
-    # BTODO: this should only create a single list for the campaign being synced, not a new list per sync.
-    # create the list for this sync
+    # create or update the mailing list for this sync
     # see: https://api.qualtrics.com/reference#create-mailing-lists
-    data = {}
-    data["libraryId"] = BeyondZConfiguration.qualtrics_library_id
-    data["name"] = "#{course.course_code} via sync #{DateTime.now}"
- 
+    mailing_list_name = "#{course.course_code} via sync"
+    mailing_list_id = nil
+
     url = URI.parse("https://#{BeyondZConfiguration.qualtrics_host}/API/v3/mailinglists")
-
     headers = {}
-    headers["Content-Type"] = "application/json"
     headers["X-API-TOKEN"] = BeyondZConfiguration.qualtrics_api_token
-
     http = Net::HTTP.new(url.host, url.port)
     http.use_ssl = true
-    request = Net::HTTP::Post.new(url.request_uri, headers)
-    request.body = data.to_json
 
-    response = http.request(request)
-    obj = JSON.parse(response.body)
+    # Use existing mailing list if it's already been created and this is a subsequent Sync To LMS
+    Rails.logger.info "### Looking for existing Qualtrics mailing list called '#{mailing_list_name}'"
+    obj = fetch_qualtrics_mailing_lists(http)
 
     if obj["meta"]["httpStatus"] != '200 - OK'
       raise Exception.new response.body
-    end
-    Rails.logger.info "### new Qualtrics mailing list API call response: #{response.inspect} - #{response.body}"
+    else
+      # No clue what is going on, but sometimes the response isn't populated even though it says 200 OK.
+      # Just retry a couple times.
+      tries = 0
+      while tries < 5 && obj["result"]["elements"].empty?
+        tries += 1
+        sleep(tries * 2) # sleep longer and longer so we don't over-poll
+        obj = fetch_qualtrics_mailing_lists(http)
+      end
 
-    mailing_list_id = obj["result"]["id"]
+      obj["result"]["elements"].select {|k,v| mailing_list_id = k["id"] if k["name"] ==  mailing_list_name}
+      Rails.logger.info "### Found existing mailing list. name=#{mailing_list_name}, id=#{mailing_list_id}" unless mailing_list_id.blank?
+
+    end
+
+    if mailing_list_id.blank?
+      url = URI.parse("https://#{BeyondZConfiguration.qualtrics_host}/API/v3/mailinglists")
+      headers = {}
+      headers["Content-Type"] = "application/json"
+      headers["X-API-TOKEN"] = BeyondZConfiguration.qualtrics_api_token
+      http = Net::HTTP.new(url.host, url.port)
+      http.use_ssl = true
+      Rails.logger.info "### Creating new Qualtrics mailing list called '#{mailing_list_name}' since we didn't find one."
+      data = {}
+      data["libraryId"] = BeyondZConfiguration.qualtrics_library_id
+      data["name"] = mailing_list_name
+      request = Net::HTTP::Post.new(url.request_uri, headers)
+      request.body = data.to_json
+
+      response = http.request(request)
+      obj = JSON.parse(response.body)
+
+      if obj["meta"]["httpStatus"] != '200 - OK'
+        raise Exception.new response.body
+      end
+      Rails.logger.info "### Qualtrics API call response for creating new mailing list: #{response.inspect} - #{response.body}"
+
+      mailing_list_id = obj["result"]["id"]
+    end
 
     # add the necessary students to this list
     # see: https://api.qualtrics.com/reference#create-contacts-import
 
     additional_data_from_join_server = JSON.parse(params[:additional_data])
+    Rails.logger.debug "### Qualtrics additional_data_from_join_server = #{additional_data_from_join_server.to_json}"
 
     sync = {}
     sync["contacts"] = []
@@ -1830,7 +1859,7 @@ class BzController < ApplicationController
         ed["Student ID"] = additional_data_from_join_server[student.id.to_s]["student_id"]
         ed["Salesforce ID"] = additional_data_from_join_server[student.id.to_s]["salesforce_id"]
       else
-        Rails.logger.info "### no additional_data_from_join_server for student.id = #{student.id} was found. Didn't set embeddedData for Qualtrics."
+        Rails.logger.info "### No Qualtrics additional_data_from_join_server for student.id = #{student.id} was found. Didn't set embeddedData"
       end
 
       s["embeddedData"] = ed
@@ -1847,14 +1876,15 @@ class BzController < ApplicationController
 
     request = Net::HTTP::Post.new(url.request_uri, headers)
     request.body = sync.to_json
-    Rails.logger.info "### sending contacts to Qualtrics with embedded data: #{request.inspect} - #{request.body}"
+    Rails.logger.debug "### Sending contact to qualtrics with embedded data: #{request.inspect} - #{request.body}"
+
     response = http.request(request)
     obj = JSON.parse(response.body)
     if obj["meta"]["httpStatus"] != '200 - OK'
       raise Exception.new response.body
     end
 
-    Rails.logger.info "###: received response from qualtrics API for sending contact information: #{response.body}"
+      Rails.logger.info "###: Received response from qualtrics API for sending contact information: #{response.body}"
 
     # now create the links for the people...
     # see https://api.qualtrics.com/reference#distribution-create-1
@@ -1885,6 +1915,26 @@ class BzController < ApplicationController
     obj
   end
 
+  # Gets an object populated with the response to: https://api.qualtrics.com/reference#list-mailing-lists-1
+  #
+  # Note: Sometimes the response isn't populated even though it says 200 OK. Just try a couple times.
+  def fetch_qualtrics_mailing_lists(http)
+    url = URI.parse("https://#{BeyondZConfiguration.qualtrics_host}/API/v3/mailinglists")
+    headers = {}
+    headers["X-API-TOKEN"] = BeyondZConfiguration.qualtrics_api_token
+
+    request = Net::HTTP::Get.new(url.request_uri, headers)
+    response = http.request(request)
+    obj = JSON.parse(response.body)
+
+    if obj["meta"]["httpStatus"] != '200 - OK'
+      raise Exception.new response.body
+    else
+      Rails.logger.debug "### Qualtrics mailing list lookup API call response: #{response.body}"
+    end
+
+    obj
+  end
 
   def do_qualtrics_list(course_id, http, mailing_list_id, students_list, survey_id, magic_field_name, distrib_name)
     if students_list.any?


### PR DESCRIPTION
Changes
- Don't create a new Qualtrics mailing lists each time we sync and add the contacts with their info. Instead, use one per course.
- Fix sending embedded data to Qualtrics when creating the Contact on that site. Needed to 'to_s' on the integer id. Also, made some logs actually useful

Testing
- I tested Sync To LMS multiple times, adding a new user each time. The embedded data comes across and I confirmed that it looks up the existing mailing list and adds the Contacts to that or creates a new list if it doesn't exist.

See: https://app.asana.com/0/1128645836596228/1135946954703427 and https://app.asana.com/0/1135289657824722/1135291809237723
