### PR TITLE
Get rid of npm install error that wasn't actually a problem but caused confusion

### DIFF
--- a/gems/canvas_i18nliner/npm-shrinkwrap.json
+++ b/gems/canvas_i18nliner/npm-shrinkwrap.json
@@ -300,29 +300,29 @@
           "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.9.tgz"
         },
         "request": {
-          "version": "2.88.0",
-          "from": "request@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+          "version": "2.76.0",
+          "from": "request@>=2.61.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.76.0.tgz",
           "dependencies": {
             "aws-sign2": {
-              "version": "0.7.0",
-              "from": "aws-sign2@>=0.7.0 <0.8.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz"
+              "version": "0.6.0",
+              "from": "aws-sign2@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
             },
             "aws4": {
-              "version": "1.8.0",
-              "from": "aws4@>=1.8.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz"
+              "version": "1.7.0",
+              "from": "aws4@>=1.2.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz"
             },
             "caseless": {
-              "version": "0.12.0",
-              "from": "caseless@>=0.12.0 <0.13.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
+              "version": "0.11.0",
+              "from": "caseless@>=0.11.0 <0.12.0",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
             },
             "combined-stream": {
-              "version": "1.0.8",
-              "from": "combined-stream@>=1.0.6 <1.1.0",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+              "version": "1.0.6",
+              "from": "combined-stream@>=1.0.5 <1.1.0",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
@@ -332,9 +332,9 @@
               }
             },
             "extend": {
-              "version": "3.0.2",
-              "from": "extend@>=3.0.2 <3.1.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz"
+              "version": "3.0.1",
+              "from": "extend@>=3.0.0 <3.1.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
             },
             "forever-agent": {
               "version": "0.6.1",
@@ -342,9 +342,9 @@
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
             },
             "form-data": {
-              "version": "2.3.3",
-              "from": "form-data@>=2.3.2 <2.4.0",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+              "version": "2.1.4",
+              "from": "form-data@>=2.1.1 <2.2.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
               "dependencies": {
                 "asynckit": {
                   "version": "0.4.0",
@@ -354,66 +354,110 @@
               }
             },
             "har-validator": {
-              "version": "5.1.3",
-              "from": "har-validator@>=5.1.0 <5.2.0",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+              "version": "2.0.6",
+              "from": "har-validator@>=2.0.6 <2.1.0",
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
               "dependencies": {
-                "ajv": {
-                  "version": "6.10.2",
-                  "from": "ajv@>=6.5.5 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+                "is-my-json-valid": {
+                  "version": "2.17.2",
+                  "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
                   "dependencies": {
-                    "fast-deep-equal": {
-                      "version": "2.0.1",
-                      "from": "fast-deep-equal@>=2.0.1 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz"
-                    },
-                    "fast-json-stable-stringify": {
+                    "generate-function": {
                       "version": "2.0.0",
-                      "from": "fast-json-stable-stringify@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz"
+                      "from": "generate-function@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
-                    "json-schema-traverse": {
-                      "version": "0.4.1",
-                      "from": "json-schema-traverse@>=0.4.1 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz"
-                    },
-                    "uri-js": {
-                      "version": "4.2.2",
-                      "from": "uri-js@>=4.2.2 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+                    "generate-object-property": {
+                      "version": "1.2.0",
+                      "from": "generate-object-property@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "dependencies": {
-                        "punycode": {
-                          "version": "2.1.1",
-                          "from": "punycode@>=2.1.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz"
+                        "is-property": {
+                          "version": "1.0.2",
+                          "from": "is-property@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                         }
                       }
+                    },
+                    "is-my-ip-valid": {
+                      "version": "1.0.0",
+                      "from": "is-my-ip-valid@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz"
+                    },
+                    "jsonpointer": {
+                      "version": "4.0.1",
+                      "from": "jsonpointer@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
+                    },
+                    "xtend": {
+                      "version": "4.0.1",
+                      "from": "xtend@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     }
                   }
                 },
-                "har-schema": {
-                  "version": "2.0.0",
-                  "from": "har-schema@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz"
+                "pinkie-promise": {
+                  "version": "2.0.1",
+                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                  "dependencies": {
+                    "pinkie": {
+                      "version": "2.0.4",
+                      "from": "pinkie@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "hawk": {
+              "version": "3.1.3",
+              "from": "hawk@>=3.1.3 <3.2.0",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+              "dependencies": {
+                "hoek": {
+                  "version": "2.16.3",
+                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                },
+                "boom": {
+                  "version": "2.10.1",
+                  "from": "boom@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "from": "sntp@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "http-signature": {
-              "version": "1.2.0",
-              "from": "http-signature@>=1.2.0 <1.3.0",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+              "version": "1.1.1",
+              "from": "http-signature@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
               "dependencies": {
                 "assert-plus": {
-                  "version": "1.0.0",
-                  "from": "assert-plus@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                  "version": "0.2.0",
+                  "from": "assert-plus@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
                 },
                 "jsprim": {
                   "version": "1.4.1",
                   "from": "jsprim@>=1.2.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
                   "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "from": "assert-plus@1.0.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                    },
                     "extsprintf": {
                       "version": "1.3.0",
                       "from": "extsprintf@1.3.0",
@@ -439,14 +483,19 @@
                   }
                 },
                 "sshpk": {
-                  "version": "1.16.1",
+                  "version": "1.14.1",
                   "from": "sshpk@>=1.7.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
                   "dependencies": {
                     "asn1": {
-                      "version": "0.2.4",
+                      "version": "0.2.3",
                       "from": "asn1@>=0.2.3 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz"
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                    },
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "from": "assert-plus@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                     },
                     "dashdash": {
                       "version": "1.14.1",
@@ -457,11 +506,6 @@
                       "version": "0.1.7",
                       "from": "getpass@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz"
-                    },
-                    "safer-buffer": {
-                      "version": "2.1.2",
-                      "from": "safer-buffer@>=2.0.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
                     },
                     "jsbn": {
                       "version": "0.1.1",
@@ -474,14 +518,14 @@
                       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
                     },
                     "ecc-jsbn": {
-                      "version": "0.1.2",
+                      "version": "0.1.1",
                       "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz"
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                     },
                     "bcrypt-pbkdf": {
-                      "version": "1.0.2",
+                      "version": "1.0.1",
                       "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
                     }
                   }
                 }
@@ -503,47 +547,42 @@
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
-              "version": "2.1.24",
-              "from": "mime-types@>=2.1.19 <2.2.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+              "version": "2.1.18",
+              "from": "mime-types@>=2.1.7 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.40.0",
-                  "from": "mime-db@1.40.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz"
+                  "version": "1.33.0",
+                  "from": "mime-db@>=1.33.0 <1.34.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz"
                 }
               }
             },
-            "oauth-sign": {
-              "version": "0.9.0",
-              "from": "oauth-sign@>=0.9.0 <0.10.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz"
+            "node-uuid": {
+              "version": "1.4.8",
+              "from": "node-uuid@>=1.4.7 <1.5.0",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz"
             },
-            "performance-now": {
-              "version": "2.1.0",
-              "from": "performance-now@>=2.1.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz"
+            "oauth-sign": {
+              "version": "0.8.2",
+              "from": "oauth-sign@>=0.8.1 <0.9.0",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
             },
             "qs": {
-              "version": "6.5.2",
-              "from": "qs@>=6.5.2 <6.6.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz"
+              "version": "6.3.2",
+              "from": "qs@>=6.3.0 <6.4.0",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz"
             },
-            "safe-buffer": {
-              "version": "5.2.0",
-              "from": "safe-buffer@>=5.1.2 <6.0.0",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz"
+            "stringstream": {
+              "version": "0.0.5",
+              "from": "stringstream@>=0.0.4 <0.1.0",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
             },
             "tough-cookie": {
-              "version": "2.4.3",
-              "from": "tough-cookie@>=2.4.3 <2.5.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+              "version": "2.3.4",
+              "from": "tough-cookie@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
               "dependencies": {
-                "psl": {
-                  "version": "1.3.0",
-                  "from": "psl@>=1.1.24 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/psl/-/psl-1.3.0.tgz"
-                },
                 "punycode": {
                   "version": "1.4.1",
                   "from": "punycode@>=1.4.1 <2.0.0",
@@ -552,14 +591,9 @@
               }
             },
             "tunnel-agent": {
-              "version": "0.6.0",
-              "from": "tunnel-agent@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
-            },
-            "uuid": {
-              "version": "3.3.2",
-              "from": "uuid@>=3.3.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz"
+              "version": "0.4.3",
+              "from": "tunnel-agent@>=0.4.1 <0.5.0",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
             }
           }
         },


### PR DESCRIPTION
Overall canvas uses node package request@2.76 which is the last version that supports our node version. However, request@2.88 was being specified in the gems/canvas_i18nliner/npm-shrinkwrap which needs node 4+ but we're on node 0.12.14. Have to check this in to test a deploy to staging since that's where this failure was happening and Capistrano deploy works off checked in files.