### PR TITLE
Disable New Relic using an ENV var until we figure out and fix why its not working

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,9 @@
 environment_configuration(defined?(config) && config) do |config|
   # Settings specified here will take precedence over those in config/application.rb
 
+  # Temporarily disable New Relic until we get to the bottom of why it's not working.
+  ENV['NEW_RELIC_ENABLED'] = "false"
+
   # The production environment is meant for finished, "live" apps.
   # Code is not reloaded between requests
   config.cache_classes = true


### PR DESCRIPTION
This was done temporarily on the staging server, but rather than revert that change it'll be easier to troubleshoot and move forward with getting New Relic working to leave the code in and disable with an ENV var for now.