### PR TITLE
Add dependency 'nan' to npm-shrink for contextify. 

### DIFF
--- a/gems/canvas_i18nliner/npm-shrinkwrap.json
+++ b/gems/canvas_i18nliner/npm-shrinkwrap.json
@@ -680,6 +680,11 @@
               "version": "1.3.0",
               "from": "bindings@>=1.2.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz"
+            },
+            "nan": {
+              "version": "2.1.0",
+              "from": "nan@>=2.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz"
             }
           }
         }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9946,6 +9946,11 @@
               "version": "1.3.0",
               "from": "bindings@>=1.2.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz"
+            },
+            "nan": {
+              "version": "2.1.0",
+              "from": "nan@>=2.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz"
             }
           }
         }


### PR DESCRIPTION
This was causing 'nan' module not found errors in the compile assets build. I think it was introduced with my last change to pin jsdom at a consistent version. Somehow the nan dependency wasn't in there but `npm show contextify@0.1.15` says that it is a dependency.