### PR TITLE
Add structured JSON instrumentation

### DIFF
--- a/Gemfile.d/heroku.rb
+++ b/Gemfile.d/heroku.rb
@@ -3,4 +3,4 @@
 #gem 'rails_12factor', group: :production
 
 # Structured JSON logging to stdout.
-gem "logjam_agent", github: "rshipp/logjam_agent"
+gem "logjam_agent", github: "beyond-z/logjam_agent"

--- a/Gemfile.d/heroku.rb
+++ b/Gemfile.d/heroku.rb
@@ -2,5 +2,5 @@
 # Commented out until we actually cutover to Heroku since this disables the current logging on our AWS EC2 instance
 #gem 'rails_12factor', group: :production
 
-# New Relic tracking.
-gem 'newrelic_rpm'
+# Structured JSON logging to stdout.
+gem "logjam_agent", github: "rshipp/logjam_agent"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,16 @@ GIT
     active_model_serializers (0.9.0.alpha1)
       activemodel (>= 3.2)
 
+GIT
+  remote: https://github.com/rshipp/logjam_agent.git
+  revision: 519d94489d0bf48ef72d511ad1f2de1b4c5404b5
+  specs:
+    logjam_agent (0.29.2)
+      activesupport
+      ffi-rzmq (>= 2.0.4)
+      ffi-rzmq-core (>= 1.0.5)
+      time_bandits (>= 0.6.0)
+
 PATH
   remote: gems/activesupport-suspend_callbacks
   specs:
@@ -559,6 +569,10 @@ GEM
       rake
     ffi-icu (0.1.10)
       ffi (~> 1.0, >= 1.0.9)
+    ffi-rzmq (2.0.7)
+      ffi-rzmq-core (>= 1.0.7)
+    ffi-rzmq-core (1.0.7)
+      ffi
     flamegraph (0.1.0)
       fast_stack
     folio-pagination (0.0.11)
@@ -685,7 +699,6 @@ GEM
     net-ssh (3.2.0)
     netaddr (1.5.0)
     netrc (0.11.0)
-    newrelic_rpm (6.6.0.358)
     oauth-instructure (0.4.10)
     oauth2 (1.0.0)
       faraday (>= 0.8, < 0.10)
@@ -904,9 +917,13 @@ GEM
       rack (~> 1.0)
     thor (0.20.3)
     thread_safe (0.3.6)
+    thread_variables (0.2.0)
     thrift (0.8.0)
     thrift_client (0.8.4)
       thrift (~> 0.8.0)
+    time_bandits (0.11.0)
+      activesupport (>= 2.3.2)
+      thread_variables
     timecop (0.6.3)
     tins (1.6.0)
     treetop (1.4.15)
@@ -1049,6 +1066,7 @@ DEPENDENCIES
   linked_in!
   listen (~> 1.3)
   live_events!
+  logjam_agent!
   lti_outbound!
   mail (= 2.5.4)
   marginalia (= 1.3.0)
@@ -1063,7 +1081,6 @@ DEPENDENCIES
   net-ldap (= 0.10.1)
   net-ssh (= 3.2.0)
   netaddr (= 1.5.0)
-  newrelic_rpm
   nokogiri (= 1.6.6.2.20150813143452)!
   nokogiri-xmlsec-me-harder (= 0.9.3pre)!
   oauth-instructure (= 0.4.10)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,9 +1,6 @@
 environment_configuration(defined?(config) && config) do |config|
   # Settings specified here will take precedence over those in config/application.rb
 
-  # Temporarily disable New Relic until we get to the bottom of why it's not working.
-  ENV['NEW_RELIC_ENABLED'] = "false"
-
   # The production environment is meant for finished, "live" apps.
   # Code is not reloaded between requests
   config.cache_classes = true

--- a/config/initializers/logjam_agent.rb
+++ b/config/initializers/logjam_agent.rb
@@ -1,0 +1,74 @@
+module LogjamAgent
+  # Configure the application name (required). Must not contain dots or hyphens.
+  self.application_name = "canvas-lms"
+
+  # Configure the environment name (optional). Defaults to Rails.env.
+  # self.environment_name = Rails.env
+
+  # Configure the application revision (optional). Defaults to (git rev-parse HEAD).
+  # self.application_revision = "f494e11afa0738b279517a2a96101a952052da5d"
+
+  # Configure request data forwarder for stdout.
+  add_forwarder(:stdout)
+
+  # Configure ip obfuscation. Defaults to no obfuscation.
+  self.obfuscate_ips = true
+
+  # Configure cookie obfuscation. Defaults to [/_session\z/].
+  self.obfuscated_cookies = [/_session\z/]
+
+  # Configure asset request logging and forwarding. Defaults to ignore
+  # asset requests in development mode. Set this to false if you need
+  # to debug asset request handling.
+  self.ignore_asset_requests = Rails.env.development?
+
+  # Disable ActiveSupport::Notifications (and thereby logging) of ActionView
+  # render events. Defaults to false.
+  # self.ignore_render_events = Rails.env.production?
+
+  # Configure log level for logging on disk: only lines with a log level
+  # greater than or equal to the specified one will be logged to disk.
+  # Defaults to Logger::INFO. Note that logjam_agent extends the standard
+  # logger log levels by the constant NONE, which indicates no logging.
+  # Also, setting the level has no effect on console logging in development.
+  # self.log_device_log_level = Logger::WARN   # log warnings, errors, fatals and unknown log messages
+  # self.log_device_log_level = Logger::NONE   # log nothing at all
+
+  # Configure lines which will not be logged locally.
+  # They will still be sent to the logjam server. Defaults to nil.
+  self.log_device_ignored_lines = /^\s*Rendered/
+
+  # It is also possible to ovveride this on a per request basis,
+  # for example in a Rails before_action
+  # LogjamAgent.request.log_device_ignored_lines = /^\s*(?:Rendered|REDIS)/
+
+  # Configure maximum size of logged parameters and environment variables sent to
+  # logjam. Defaults to 1024.
+  # self.max_logged_param_size = 1024
+
+  # Configure maximum size of logged parameters and environment variables sent to
+  # logjam. Defaults to 1024 * 100.
+  # self.max_logged_cookie_size = 1024 * 100
+
+  # Configure maximum log line length. Defaults to 2048.
+  # This setting only applies to the lines sent with the request.
+  self.max_line_length = 2048
+
+  # Configure max bytes allowed for all log lines. Defaults to 1Mb.
+  # This setting only applies to the lines sent with the request.
+  self.max_bytes_all_lines = 1024 * 1024
+
+  # Configure compression method. Defaults to NO_COMPRESSION. Available
+  # compression methods are ZLIB_COMPRESSION, SNAPPY_COMPRESSION, LZ4_COMPRESSION.
+  # Snappy and LZ4 are faster and less CPU intensive than ZLIB, ZLIB achieves
+  # higher compression rates. LZ4 is faster to decompress than Snappy
+  # and recommended.
+  # self.compression_method = ZLIB_COMPRESSION
+  # self.compression_method = SNAPPY_COMPRESSION
+  # self.compression_method = LZ4_COMPRESSION
+
+  # Activate the split between hard and soft-exceptions. Soft exceptions are
+  # all exceptions below a log level of Logger::ERROR. Logjam itself can then
+  # display those soft exceptions differently. Defaults to `true`.
+  # self.split_hard_and_soft_exceptions = true
+end


### PR DESCRIPTION
This gives us structured JSON performance instrumentation for Canvas. It's currently using my fork of the `logjam_agent` pending merge/close of my [upstream PR](https://github.com/skaes/logjam_agent/pull/35) - we can move this to a fork under the beyond-z account if we want, I just don't have repo-create permissions on the org.