### PR TITLE
Fix JSON logger

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,8 +1,5 @@
 environment_configuration(defined?(config) && config) do |config|
   # Settings specified here will take precedence over those in config/application.rb
-  
-  # Temporarily disable New Relic until we get to the bottom of why it's not working.
-  ENV['NEW_RELIC_ENABLED'] = "false"
 
   # In the development environment your application's code is reloaded on
   # every request.  This slows down response time but is perfect for development

--- a/config/initializers/logjam_agent.rb
+++ b/config/initializers/logjam_agent.rb
@@ -1,6 +1,6 @@
 module LogjamAgent
   # Configure the application name (required). Must not contain dots or hyphens.
-  self.application_name = "canvas-lms"
+  self.application_name = "canvas_lms"
 
   # Configure the environment name (optional). Defaults to Rails.env.
   # self.environment_name = Rails.env

--- a/config/initializers/logjam_agent.rb
+++ b/config/initializers/logjam_agent.rb
@@ -71,4 +71,13 @@ module LogjamAgent
   # all exceptions below a log level of Logger::ERROR. Logjam itself can then
   # display those soft exceptions differently. Defaults to `true`.
   # self.split_hard_and_soft_exceptions = true
+
+  # Patch the STDOUT Forwarder to send to Rails' logger instead, since stdout
+  # seems to get lost somewhere.
+  class STDOUTForwarder
+    def forward(data, options={})
+      msg = LogjamAgent.json_encode_payload(data)
+      Rails.logger.info msg
+    end
+  end
 end


### PR DESCRIPTION
Task: https://app.asana.com/0/1128645836596228/1137434504174314/f

Related: #530 

Summary: `$stdout` doesn't go to the passenger logs for whatever reason, so we're using @hcli-work's idea of patching logjam to send to `Rails.logger` instead. It's not ideal, but it works, and we don't want to spend a bunch more time on this. 

End result of this PR is JSON logs go to `production.log` so `honeytail` can pick them up.