### PR TITLE
Avoid logging spurios errors when doing an assignment

### DIFF
--- a/app/controllers/bz_controller.rb
+++ b/app/controllers/bz_controller.rb
@@ -720,9 +720,11 @@ class BzController < ApplicationController
     data.save
 
     # now that the user's work is safely saved, we will go back and do addon work
-    # like micrograding
+    # like micrograding -- we only micro-grade (aka auto-grade) pages in modules, not assignments
+    # assignment magic fields are just for persistant storage.
+    is_wiki_page = request.referrer.match(/\/courses\/\d+\/pages\//)
 
-    if was_new && !was_optional && (field_type != 'checkbox' || !answer.nil?) # Checkboxes are optional by nature unless there is an answer
+    if is_wiki_page && was_new && !was_optional && (field_type != 'checkbox' || !answer.nil?) # Checkboxes are optional by nature unless there is an answer
       bzg = BZGrading.new
 
       course_id = request.referrer[/\/courses\/(\d+)\//, 1]


### PR DESCRIPTION
"Magic Fields" where originally only used in pages (aka wiki pages)
and assumed there was a Course Participation assignment to automatically
grade. It would log errors and warnings and info if it couldn't update
the grade. However, later, we let assignments use magic fields too and
naturally the automatic participation and mastery grading stuff isn't
meant to happen there. So just short circuit it to avoid cluttering up
the logs with TONS of spurious errors and warnings.

Note: the regex I used to `match` on is identical to the one below where
we pull out the page name (minus actually pulling out the name).

TESTING:
- Loaded in dev env and verified logs and functionality of magic fields
  for a module (regression)
- Did the same for an assignment to make sure the logs are gone and the
  fields still work