### PR TITLE
Handle loading files in the development environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,14 @@ client_apps/canvas_quizzes/node_modules/
 client_apps/canvas_quizzes/dist/
 client_apps/canvas_quizzes/tmp/
 config/*.example
+config/*.yml
+# Exclude the config files that are actually checked in and should be part of the image
+# Every other config should be set at runtime.
+!config/brandable_css.yml
+!config/browsers.yml
+!config/fontcustom.yml
+!config/styleguide.yml
+!config/testem.yml
 coverage/
 coverage-js/
 gems/*/node_modules/


### PR DESCRIPTION
    I noticed that dev config files were being built into the Docker image
    after using the dev env and then re-building. In the process of ignoring
    those configs in the actual build, the dynamic syllabus broke and wouldn't
    load the images.
    
    The dynamic syllabus uses Canvas's file system to fetch and show the images on
    the CourseParts (aka modules aka cards). Because of some logic to stream files
    over a "Files Domain" if one is set doesn't handle ports too well, we were in
    and infinite loop trying to load those images. I had fixed this in the dev env
    before by explicitly setting the "files_domain" setting to be host:port, but
    that was a troubleshooting hack that I subsequently forgot about and removed (but
    didn't notice until a full Docker rebuild b/c the old config value was built
    into the docker image). This fix is also a bit hacky b/c I'm limiting it to
    the dev env, but I just want to be on the safe side since we don't have specs running
    and I don't have confidence that there won't be any negative side effects if
    I make the change for prod as well.
    
    TESTING:
    - Rebuilt the Canvas containers from scratch and checked that the dynamic syllabus
      (aka the Home page) showed images pulled from S3.