### PR TITLE
Stop scrolling please

### DIFF
--- a/public/javascripts/rubric_assessment.js
+++ b/public/javascripts/rubric_assessment.js
@@ -174,7 +174,7 @@ window.rubricAssessment = {
           $ratingsContainers.css('height', (maxHeight - 10) + 'px');
         }
       });
-      $("html,body").scrollTop(scrollTop); 
+      //$("html,body").scrollTop(scrollTop);
     }
   },
 


### PR DESCRIPTION
Task: https://app.asana.com/0/1128645836596228/1138467255207468/f

This is a super weird one. I'm not sure what this behavior is supposed to be, but for some reason there's a [timer](https://github.com/beyond-z/canvas-lms/blob/43a0fe8be871a6baf1aeee74c0bb60e93e3b1a5f/public/javascripts/rubric_assessment.js#L157) that scrolls to the top of the page every 2.5 seconds if you've opened a rubric on the grades page.

This fix just comments out the scroll command and leaves the rest, but frankly I have no idea what any of this is for, and this is digging into Canvas code. There's probably a better way to solve this.

Opinions?

*SIde note: the reason the bug happens on Chrome and not Safari, is that scrollTop isn't well-supported cross-browsers.*