### PR TITLE
 Fix log file permission errors during Capistrano deploy.

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -118,7 +118,7 @@ namespace :deploy do
       # and this process runs as the deploy user who is in the canvasadmin group whereas the apache
       # application runs as canvasuser so when logs get rotated they are put in the canvasuser group
       execute :sudo, 'chown -R canvasuser:canvasadmin', release_path.join('log/') 
-      execute :sudo, 'chmod -R g+w', release_path.join('log')
+      execute :sudo, 'chmod -R g+sw', release_path.join('log')
     end
   end
 

--- a/lib/canvas_logger.rb
+++ b/lib/canvas_logger.rb
@@ -10,6 +10,7 @@ class CanvasLogger < ActiveSupport::Logger
       FileUtils.mkdir_p(File.dirname(log_path))
     end
     super(log_path, level)
+    @logdev = GroupWritableLogDevice.new(log_path)
     @log_path = log_path
     @skip_thread_context = options[:skip_thread_context]
   end
@@ -50,4 +51,20 @@ class CanvasLogger < ActiveSupport::Logger
       @captured_messages = nil
     end
   end
+
+  # On production we're running the server as a particular user, but we have the log
+  # file permissions to be group writable. This is because Capistrano deploys run
+  # as a different user and have to write to the logs while running rake tasks.
+  # This LogDevice overrides the default permissions on file create from 644 to 664.
+  # 
+  # Note: when the Rails.logger rotates the log b/c it hits the shift_size (instead of waiting for
+  # logrotate to run on the machine) it fubar's the permissions b/c it just let's the kernel do it's
+  # thing based on umask. It feels risky to muck with the umask, so this is a safer hack to keep
+  # the thing group writable.
+  class GroupWritableLogDevice < Logger::LogDevice
+    def create_logfile(filename)
+      super.tap {|f| f.chmod(0664) }
+    end
+  end
+
 end


### PR DESCRIPTION
We have logrotate configured to run weekly on the servers, but Rails.logger also
has a built in logrotate functionality. The default is to rotate the logs
when they hit 1MB. Since the server is running as a particular user and does
a File.rename, it's up to the kernel to set the file permissions based on the umask.
See the calls to create_logfile here: https://github.com/ruby/ruby/blob/v2_1_9/lib/logger.rb

This fix alters the behavior of create_logfile and uses `664` permissions so that
users in the group can still write it. HOWEVER, to make that work you need to make sure
new files created in the log directory inherit the group id. Do this by setting the setgid
bit on the directory. E.g. `sudo chmod g+s /our/log/dir` and make sure the directory itself
is in the proper group.

TESTING:
- I changed the line in lib/canvas_logger.rb from:
    `@logdev = GroupWritableLogDevice.new(log_path)`
  to
    `@logdev = GroupWritableLogDevice.new(log_path, shift_size: 1024)`
- This makes the log roll every 1KB.
- I then set the setgid bit on the log dir.
- I then changed the group permission on the log file and the log directory itself
  to be something other than what the server was running as.
- Then I hit the app and watched the files rotate with the permissions intact.