### PR TITLE
Add support for loading ENV variables into the Rails app using .env files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+.env*
 .git
 .bundle/config
 client_apps/canvas_quizzes/node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,11 @@
 #
 # That's what .git/info/exclude and core.excludesfile are for :)
 
+# See https://github.com/bkeepers/dotenv#can-i-use-dotenv-in-production
+# for more info about why these are the only .env files we .gitignore
+/.env
+.env.*.local
+
 .bundle/
 .byebug_history
 /.yardoc/
@@ -87,8 +92,6 @@ docker-compose.override.yml
 
 # Local Development only files
 *.dev
-.env
-
 
 # ignore JetBrains IDEs files
 .idea/*

--- a/Gemfile.d/app.rb
+++ b/Gemfile.d/app.rb
@@ -17,6 +17,10 @@ else
   gem 'activesupport-json_encoder', '1.1.0'
 end
 
+# Support for configurign our environment variables using a .env file.
+# See https://github.com/bkeepers/dotenv#can-i-use-dotenv-in-production
+gem 'dotenv-rails'
+
 gem 'ruby-openid'
 
 gem 'encrypted_cookie_store-instructure', '1.1.12', require: 'encrypted_cookie_store'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -549,6 +549,10 @@ GEM
     docile (1.1.3)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.7.5)
+    dotenv-rails (2.7.5)
+      dotenv (= 2.7.5)
+      railties (>= 3.2, < 6.1)
     dynamic_form (1.1.4)
     encrypted_cookie_store-instructure (1.1.12)
       actionpack (>= 3.2, < 4.3)
@@ -1018,6 +1022,7 @@ DEPENDENCIES
   diigo!
   diplomat (= 0.15.0)
   docile (= 1.1.3)
+  dotenv-rails
   dress_code (= 1.0.2)!
   dynamic_form (= 1.1.4)
   encrypted_cookie_store-instructure (= 1.1.12)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -105,7 +105,8 @@ namespace :deploy do
   desc "Copy config files from <deploy_to>/config to the release directory"
   task :copy_config do
     on roles(:app) do
-      execute :sudo, 'cp -rp', "#{fetch(:deploy_to)}/config/*", "#{release_path}/config"
+      execute :sudo, 'rsync -avr --exclude='*.env*', "#{fetch(:deploy_to)}/config/*", "#{release_path}/config"
+      execute :sudo, 'cp -p', "#{fetch(:deploy_to)}/config/.env.local", "#{release_path}"
     end
   end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,7 @@ services:
       - ./script:/app/script
       - ./spec:/app/spec
       - ./db/migrate:/app/db/migrate
+      - ./docker-compose:/app/docker-compose
      # Note: if you try and mount the entire "public" directory as a volume, it will mask the stuff generated inside 
      # the container at build time during compile_assets and you'll get all sorts of "not found" console errors.
     networks:

--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -1,0 +1,12 @@
+# Development only environment variables
+# Use this as a template for what needs to be configured in staging and prod
+# but in staging and prod name the file: .env.local
+# We only .gitignore .env.*.local files and the OG .env file b/c those have the values 
+# for that server in them and should not be checked in.
+# See this for more info: https://github.com/bkeepers/dotenv#can-i-use-dotenv-in-production
+
+DOMAIN=canvasweb
+PGDATABASE=canvas
+PGHOST=canvasdb
+PGUSER=canvas
+

--- a/docker-compose/config/database.yml
+++ b/docker-compose/config/database.yml
@@ -1,20 +1,27 @@
-common: &common
+common: &default_settings
   adapter: postgresql
-  host: canvasdb
+  host: <%= ENV['PGHOST'] %> 
   encoding: utf8
-  username: canvas
+  database: <%= ENV['PGDATABASE'] %>
+  username: <%= ENV['PGUSER'] %>
   timeout: 5000
-  prepared_statements: false
 
 development:
-  <<: *common
-  database: canvas
+  <<: *default_settings
   open: true
 
 test:
-  <<: *common
+  <<: *default_settings
   database: canvas_test_rails3_<%= ENV['TEST_ENV_NUMBER'] %>
   shard1: canvas_test_rails3_shard1
   shard2: canvas_test_rails3_shard2
   test_shard_1: canvas_test_rails3_shard1
   test_shard_2: canvas_test_rails3_shard2
+
+
+staging:
+  <<: *default_settings
+
+production:
+  <<: *default_settings
+

--- a/docker-compose/config/domain.yml
+++ b/docker-compose/config/domain.yml
@@ -1,5 +1,16 @@
-test:
-  domain: localhost
+common: &default_settings
+  domain: <%= ENV['DOMAIN'] %>
 
 development:
-  domain: "canvasweb"
+  <<: *default_settings
+
+test:
+  <<: *default_settings
+  domain: localhost
+
+staging:
+  <<: *default_settings
+
+production:
+  <<: *default_settings
+

--- a/docker-compose/scripts/docker_compose_run.sh
+++ b/docker-compose/scripts/docker_compose_run.sh
@@ -23,6 +23,7 @@ else
 fi
 
 cp -a /app/docker-compose/config/* /app/config/
+cp -a /app/docker-compose/.env /app/.env
 
 echo "Checking if the AWS ENV vars are setup"
 if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then


### PR DESCRIPTION
We're prepping to move the Portal from an AWS EC2 instance to Heroku.
Everything in Heroku must be checked in to src ctrl and anything server or
environment specific or secret must be set through environment
variables. We need to cut-over all our config files to read from ENV vars instead
of having the values hardcoded in local config files that are not checked in.

This pull request adds the dotenv gem to help with that. Consider that we need
the ENV vars available in these scenarios:
- in the process spawend by Apache + Passenger
- in the process that Capistrano uses to deploy (since it runs rake tasks)
- in the process spawned from the shell where you run rake tasks or load the rails console
- from a cronjob in the crontab environment

Also, consider the fact that Heroku already has support for .env files. Commands like `heroku config:push --overwrite --remote production` and `heroku config:pull --overwrite --remote production` operate using the `.env` file where you're running the command.

We _could_ write a wrapper script to set the ENV vars and make sure the script is run in
all these scenarios. This would mean calling the script from Apache/Passenger,
.bashrc (or .bash_profile), in the Capistrano deploy script, and from crontab (may actually
have to hardcode for that one).

Instead, let's just let Rails load the ENV vars into it's environment using a .env file and the
dotenv gem so we don't have to deal with all that. For more info see
https://github.com/bkeepers/dotenv (especially the "dotenv in production" section):

The way we'll do that is for the Docker dev env, have all the dev values checked into
`docker-compose/.env` but for staging and prod we'll put those ENV values in a `.env.local`
file that Capistrano will copy to the app root on deploy. When reviewing this PR, keep in mind that everything docker-compose related is dev env only stuff.

Here are a couple articles to read:
- https://medium.com/@rdsubhas/ruby-in-production-lessons-learned-36d7ab726d99
- https://www.honeybadger.io/blog/ruby-guide-environment-variables/
- https://coderwall.com/p/djrfra/pass-the-database-pwd-to-rails-with-an-environment-variable
- https://www.phusionpassenger.com/library/indepth/environment_variables.html

I cutover the database connection and domain configs to read from environment
variables as a proof of concept in order to be able to test the scenarios below since
I assume that whatever runs would need to access the database!

TESTING:
- do a Capistrano deploy and make sure the ENV var values are set and the deploy works
- run a cronjob that needs to access the DB and make sure it works
- run a rake task from the shell that needs to access the DB and make sure it works
- load the rails console and make sure they're set using `ENV['DOMAIN']`
- make sure the app actually loads and can read from the DB.

Note: once this is pushed and tested in staging, I'll do a followup PR cutting over all the configs and checking them into the `config` -- see this for where that's at: https://github.com/sadleb/canvas-lms/compare/bz-staging..857709656c88326dbb6a91bd48944a65c7fba214
