### PR TITLE
Create dev and test only UI tool to reset Magic Fields.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2251,6 +2251,11 @@ class ApplicationController < ActionController::Base
   end
   helper_method :request_delete_account_link
 
+  def show_dev_tools
+    BeyondZConfiguration.dev_tools_enabled
+  end
+  helper_method :show_dev_tools
+
   def setup_live_events_context
     ctx = {}
     ctx[:root_account_id] = @domain_root_account.global_id if @domain_root_account

--- a/app/controllers/bz_controller.rb
+++ b/app/controllers/bz_controller.rb
@@ -815,6 +815,15 @@ class BzController < ApplicationController
     render :json => response_object
   end
 
+  # This is not meant to be run in production! It's only for dev, test, and staging servers
+  def reset_user_retained_data
+    raise NotImplementedError.new "This method is not implemented for this configuration" unless BeyondZConfiguration.dev_tools_enabled
+    raise ActionController::ParameterMissing.new "You must pass a user_id parameter to this method" unless params[:user_id]
+    RetainedData.where(:user_id => params[:user_id]).destroy_all
+    flash[:html_notice] = t("Magic field data deleted for user_id =  %{user_id}.", :user_id => params[:user_id])
+    redirect_to settings_profile_path
+  end
+
   def retained_data_stats
     @aggregate_result = ActiveRecord::Base.connection.execute("
       SELECT

--- a/app/views/profile/profile.html.erb
+++ b/app/views/profile/profile.html.erb
@@ -21,7 +21,27 @@
           <i class="icon-download" aria-hidden='true'></i> <%= t("Download Course Content") %>
         <% end %>
     <% end %>
-    <% if show_request_delete_account %>
+    <% if show_dev_tools %>
+        <a href="#" class="btn button-sidebar-wide reset_retained_data_button">
+          <i class="icon-reset" aria-hidden='true'></i> <%= t("Reset Magic Fields") %>
+        </a>
+        <div <%= hidden(true) %> id="reset_retained_data_dialog">
+          <p><%= mt('Reset Magic Fields', 'Resetting these fields will permanently delete all data stored in magic fields for the user you\'re currently logged in as. This includes all their answers and interactions with the modules and assignments. This action is irreversible, and the data *cannot* be recovered. Are you sure you wish to continue?') %></p>
+
+          <%= form_for @current_user, :url => "/bz/reset_retained_data?user_id=#{@current_user.id}", :html => { :method => :post } do %>
+            <div class="button-container">
+              <button type="button" class="btn cancel_button">
+                <%= t('#buttons.cancel', 'Cancel') %>
+              </button>
+              <button type="submit" class="btn btn-danger submit_button">
+                <%= t('buttons.reset', 'Reset Magic Field Data') %>
+              </button>
+            </div>
+          <% end %>
+        </div>
+
+    <% end %>
+     <% if show_request_delete_account %>
        <a href="<%= request_delete_account_link %>" class="btn button-sidebar-wide"> <%= t('Delete My Account') %></a>
     <% end %>
   </div>

--- a/config/beyondz.yml.example
+++ b/config/beyondz.yml.example
@@ -1,6 +1,12 @@
 development:
   base_url: https://localhost
   change_password_path: /users/edit
+
+  # This controls certain UI tools available in the UI that are
+  # dangerous to have exposed on a production machine and should
+  # only be visible on dev, test, or staging environments.
+  dev_tools_enabled: true
+
   nonexistent_user_path: /users/not_on_lms
   bitly_access_token: 12345689assdfe
   help_url: http://localhost
@@ -12,6 +18,7 @@ development:
 test:
   base_url: https://test.bebraven.org/
   change_password_path: /users/edit
+  dev_tools_enabled: true
   nonexistent_user_path: /users/not_on_lms
   bitly_access_token: 12345689assdfe
   docusign_host: account-d.docusign.com
@@ -22,6 +29,7 @@ test:
 staging:
   base_url: https://stagingjoin.bebraven.org/
   change_password_path: /users/edit
+  dev_tools_enabled: true
   nonexistent_user_path: /users/not_on_lms
   bitly_access_token: 12345689assdfe
   docusign_host: account-d.docusign.com
@@ -33,6 +41,7 @@ production:
   google_analytics_account: UA-XXXXXXXX-1
   base_url: https://join.bebraven.org/
   change_password_path: /users/edit
+  dev_tools_enabled: false
   nonexistent_user_path: /users/not_on_lms
   bitly_access_token: 12345689assdfe
   help_url: https://help.bebraven.org
@@ -40,6 +49,10 @@ production:
   docusign_api_key: xxx-xxx-xxxx-xxxx
   docusign_api_secret: xxx-xxx-xxxx-xxxx
   docusign_return_url: https://portal.bebraven.org/bz/docusign_user_redirect
+
+  # Note that qualtrics doesn't have a "dev" or "testing" account option.
+  # We use the prod account for testing. Make sure you know what you're 
+  # doing if you enable it in another env.
   qualtrics_library_id: from_qualtrics_ids_section_of_account_settings
   qualtrics_api_token: from_qualtrics_ids_section_of_account_settings
   qualtrics_host: az1.qualtrics.com # the url from when you log into

--- a/config/initializers/beyondz.rb
+++ b/config/initializers/beyondz.rb
@@ -17,6 +17,12 @@ class BeyondZConfiguration
   def self.bitly_access_token
     @config[:bitly_access_token]
   end
+  
+  # True if it's safe to show UI tools that are dangerous and only
+  # safe to be exposed in a dev or testing environment.
+  def self.dev_tools_enabled
+    @config[:dev_tools_enabled]
+  end
 
   def self.docusign_host
     @config[:docusign_host]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,8 @@ CanvasRails::Application.routes.draw do
   get 'bz/load_wiki_pages' => 'bz#load_wiki_pages'
   get 'bz/user_retained_data' => 'bz#user_retained_data'
   post 'bz/user_retained_data' => 'bz#set_user_retained_data'
+  get 'bz/reset_retained_data' => 'bz#reset_user_retained_data'
+  post 'bz/reset_retained_data' => 'bz#reset_user_retained_data'
 
   get 'bz/cohort_info_upload' => 'bz#cohort_info_upload', as: :cohort_info_upload
   get 'bz/cohort_info_download' => 'bz#cohort_info_download', as: :cohort_info_download

--- a/docker-compose/config/beyondz.yml
+++ b/docker-compose/config/beyondz.yml
@@ -11,6 +11,7 @@ development:
   qualtrics_library_id: TODO
   qualtrics_api_token: TODO
   qualtrics_host: TODO
+  dev_tools_enabled: true
 
 test:
   base_url: https://test.bebraven.org/
@@ -25,3 +26,4 @@ test:
   qualtrics_library_id: TODO
   qualtrics_api_token: TODO
   qualtrics_host: TODO
+  dev_tools_enabled: true

--- a/public/javascripts/profile.js
+++ b/public/javascripts/profile.js
@@ -341,4 +341,18 @@ define([
     });
     event.preventDefault();
   });
+
+  $(".reset_retained_data_button").click(function(event) {
+    event.preventDefault();
+    $("#reset_retained_data_dialog").dialog({
+      title: 'Reset Magic Fields Data',
+      width: 500
+    });
+
+    $(".ui-dialog").focus();
+  }).fixDialogButtons();
+  $("#reset_retained_data_dialog.cancel_button").click(function() {
+    $("#reset_retained_data_dialog").dialog('close');
+  });
+
 });


### PR DESCRIPTION
... aka retained data (but we always talk about them as magic fields
with the non-engineers, so stick with that language in the UI).

This change adds a new 'Reset Magic Fields' button on the user's
[profile settings page](http://canvasweb/profile/settings). Clicking this clears out all data in these fields
for that user. This will allow us to more easily test and develop with
users in a fresh state without being required to create a new user each time.

![image](https://user-images.githubusercontent.com/5596986/67145684-470fc780-f251-11e9-92eb-f7f15ee1b4bf.png)

I put this option behind a new dev_only_tools configuration option. We can put
any future tools or features that should not be available in the production
environment behind this flag. The reason for this feature being dev only
is because it's irreversible and ripe for abuse by regional folks when troubleshooting.
I'd rather they loop engineers in if they ever need to reset all the work anyone
has done in the course. We shouldn't really ever do that...

TESTING:
- Used the UI button at http://canvasweb/profile/settings and reloaded a module
  I had done work on to see that it was cleared.
- Did the same when masquerading as a user to make sure the correct user id was used
  (as opposed to the admin)
- Ran the feature by URL hacking it to reset a different user than the one logged in
  (note: i'm not exposing this in the UI, but I want to let devs be able to do it if they need to)
- Set the config to false and ensured none of the above worked.
- Removed the config entirely and ensured none of the above worked.

RELEASE PLAN:
- Configure this to be turned on one the staging server.
- We can leave the prod server alone since the absence of the setting is interpreted as false.