### PR TITLE
Rename RAVEN_DSN env var to SENTRY_DSN to be consistent.

### DIFF
--- a/config/raven.yml
+++ b/config/raven.yml
@@ -1,4 +1,8 @@
 common: &default_settings
+  # Important note: make sure and use the variation of the setting
+  # that has the secret key set. It will fail otherwise.
+  # Login to Heroku, open the Sentry add-on and go here to get it:
+  # https://docs.sentry.io/clients/ruby/config/
   dsn: <%= ENV['SENTRY_DSN'] %>
 
 development:

--- a/config/raven.yml
+++ b/config/raven.yml
@@ -1,5 +1,5 @@
 common: &default_settings
-  dsn: <%= ENV['RAVEN_DSN'] %>
+  dsn: <%= ENV['SENTRY_DSN'] %>
 
 development:
   <<: *default_settings

--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -39,6 +39,6 @@ MAIL_DELIVERY_METHOD=test
 PGDATABASE=canvas
 PGHOST=canvasdb
 PGUSER=canvas
-#RAVEN_DSN=''
+#SENTRY_DSN=''
 REDIS_HOST_1=redis://canvasredis
 


### PR DESCRIPTION
The docs, like https://docs.sentry.io/clients/ruby/
and the sentry-raven gem use SENTRY_DSN -- I think it'll be less
confusing if we use that too.

TESTING:
- just going to blindly push this to staging / prod and make sure it works
  since we don't have Sentry setup for the dev env

RELEASE PLAN:
- update .env.local on staging and production to change the env var name
  before deploying