### PR TITLE
Update dev DB refresh to use new nightly snapshot.

### DIFF
--- a/docker-compose/scripts/dbrefresh.sh
+++ b/docker-compose/scripts/dbrefresh.sh
@@ -1,32 +1,48 @@
 #!/bin/bash
 echo "Refreshing your local dev database from the staging db"
+ 
+dbfilename='lms_staging_db_latest.sql.gz'
 
-dbfilename='lms_dev_db_dump_latest.sql.gz'
-dbfilepathgz="/tmp/$dbfilename"
+aws s3 cp "s3://canvas-staging-db-dumps/$dbfilename" - | gunzip | sed -e "
 
-aws s3 --region us-west-1 cp "s3://canvas-dev-db-dumps/$dbfilename" $dbfilepathgz
+  s/https:\/\/stagingsso.bebraven.org/http:\/\/ssoweb:3002/g;
+  s/https:\/\/stagingjoin.bebraven.org/http:\/\/joinweb:3001/g;
+
+  # Also fix up internal links in assignments to stay on staging as we navigate
+  s/https:\/\/stagingportal.bebraven.org/http:\/\/canvasweb:3000/g;
+
+  # If we have links to the kits from the LC playbook, fix that up.
+  s/https:\/\/stagingkits.bebraven.org/http:\/\/kitsweb:3005/g;
+
+  # Also fix up links to custom CSS/JS. Note: we could do this on this row but it's a pain
+  # select id, name, settings from accounts where id = 1;
+  s/https:\/\/s3.amazonaws.com\/canvas-stag-assets/http:\/\/cssjsweb:3004/g;
+
+" | docker-compose exec -T canvasdb psql -U canvas canvas
 if [ $? -ne 0 ]
 then
- echo "Failed downloading s3://canvas-dev-db-dumps/$dbfilename"
+ echo "Failed restoring from s3://canvas-staging-db-dumps/$dbfilename"
  echo "Make sure that awscli is installed: pip3 install awscli"
  echo "Also, make sure and run 'aws configure' and put in your Access Key and Secret."
  echo "Lastly, make sure your IAM account is in the Developers group. That's where the policy to access this bucket is defined."
  exit 1;
 fi
 
-gunzip < $dbfilepathgz | docker-compose exec -T canvasdb psql -U canvas canvas
-if [ $? -ne 0 ]
-then
-   echo "Error: failed loading the dev database into the dev db. File we tried to load: $dbfilepathgz"
-   exit 1;
-fi
-
-rm $dbfilepathgz
-
 # Adjust some settings for dev
+# - Set the dev encryption key hash so that dev passwords are encrypted using a dev value.
+# - Set the dev access token and access token hint, used for other apps to be able to call into the Canvas API.
 # - Make the timeout to wait for the SSO server 15 seconds since dev can be slow, especially on first start.
 # - Disable Canvas analytics which relies on a Cassandra DB. No need for this and it clutter the error log.
 cat <<EOF | docker-compose exec -T canvasdb psql -U canvas canvas
+
+  -- This is the hashed value of the dev only encryption key used in security.yml
+  update settings set value = '40ed0028ef3004ed37cbec550a57bcde82472631' where name = 'encryption_key_hash';
+
+  -- The 'Beyond Z Platform Integration' access token for dev is:
+  -- BEW8ldtbMypKZiCs8EmW2eQXfOoBpfOEwNJXwyvfIKZIpMgQzBfYUugc4V20oFgt
+  -- These are the encrypted values that the above accces token works against:
+  update access_tokens set crypted_token = 'd3cb10787c10be0c15bd036f1ae502360e4cc7c4', token_hint = 'BEW8l' where id = 2;
+
   insert into settings (name, value, created_at, updated_at)
   select 'cas_timelimit', '15', NOW(), NOW()
   where not exists (select id from settings where name = 'cas_timelimit');


### PR DESCRIPTION
The nightly snapshots stored are staging databases. This commit
just changes the dbrefresh.sh script to load from that and to run some
transformations to turn a staging DB into one that will work in the dev
environment.

TESTING:
- Ran dbrefresh.sh, verified that the script was pulling from the new S3
  staging bucket.
- Logged into http://kitsweb and checked that attendance still showed.
  This proves that other dev box can still use the Canvas API with the
  dev access tokens.
- Clicked around the portal and saw that file images loaded and than courses
  are generally accessible and show up.