### PR TITLE
Migration to add unique constraint on course_parts table

### DIFF
--- a/db/migrate/20191030013216_add_unique_on_course_parts.rb
+++ b/db/migrate/20191030013216_add_unique_on_course_parts.rb
@@ -1,0 +1,10 @@
+class AddUniqueOnCourseParts < ActiveRecord::Migration
+  tag :predeploy
+  def up
+  	add_index :course_parts, [:course_id, :title], :unique => true
+  end
+
+  def down
+  	remove_index :course_parts, column: [:course_id, :title] 
+  end
+end


### PR DESCRIPTION
https://app.asana.com/0/1109150244034467/1141477205582690

In the course_parts table, titles should be unique per course_id. This PR adds a migration to enforce that invariant at the database level.

In local dev environment, I did the following:

via rails console
ids = [54, 57, 55, 58, 59, 68, 66, 69, 67, 70, 89, 87, 88, 95, 93, 94, 126, 127, 128, 206, 207, 208, 196, 198, 200, 220, 221, 229, 230]
parts = CoursePart.where(id: ids)
parts.each(&:destroy)

and then on command line
docker-compose exec canvasweb bin/rake db:migrate  # to see if the index could be added
docker-compose exec canvasweb bin/rake db:rollback  # to see if it could be cleanly rolled back

I couldn't see a problem in local Docker env. I'll do in staging to make sure though before this gets merged. It is ready for review though.