### PR TITLE
Add new column to Course##ProjectScore tables

### DIFF
--- a/db/migrate/20191031022641_add_mock_interview_score.rb
+++ b/db/migrate/20191031022641_add_mock_interview_score.rb
@@ -1,0 +1,7 @@
+class AddMockInterviewScore < ActiveRecord::Migration
+  tag :predeploy
+  def change
+  	add_column :course71_project_scores, :total_score____mock_interview__feedback_, :integer
+  	add_column :course73_project_scores, :total_score____mock_interview__feedback_, :integer
+  end
+end


### PR DESCRIPTION
https://bebraven.zendesk.com/agent/tickets/350

Looks like a new column showed up in the export CSV download. as a result, the export was breaking each night and we weren't getting notified.

This migration just adds the appropriate column.

Test Plan: In Docker env,
rails db:migrate
then rake data:export:project_scores[71]
and then rake data:export:project_scores[73]

Verify table isn't empty (as it gets truncated right before importing data).