### PR TITLE
Fix the login redirect so it works when you aren't authenticated.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -595,7 +595,7 @@ class ApplicationController < ActionController::Base
       format.html {
         return unless fix_ms_office_redirects
         store_location
-        return redirect_to login_url(params.slice(:authentication_provider)) if !@files_domain && !@current_user
+        return redirect_to login_url(params.slice(:authentication_provider)) if !@current_user
 
         if @context.is_a?(Course) && @context_enrollment
           start_date = @context_enrollment.enrollment_dates.map(&:first).compact.min if @context_enrollment.state_based_on_date == :inactive


### PR DESCRIPTION
See: https://app.asana.com/0/1133543009734854/1154472586466515

We had made a change to improve how files were loaded since we don't
use the `files_domain` stuff, but I missed a spot where that also controlled
login behavior.

TESTING:
- I hit http://canvasweb/courses/71/assignments/1555 before the change
  when not logged in and it shows:
    "Access to this page is limited to authorized users. You do not have currently have permission to view this page."
  After the change it works.