### PR TITLE
Load gem to work with Heroku rails-autoscale add-on.

### DIFF
--- a/config/initializers/autoscale.rb
+++ b/config/initializers/autoscale.rb
@@ -1,0 +1,5 @@
+# Provides better configuration for auto-scaling dynos on Heroku
+# than the out of the box options. See:
+# https://devcenter.heroku.com/articles/rails-autoscale
+require 'rails_autoscale_agent' if ENV['RAILS_AUTOSCALE_URL']
+


### PR DESCRIPTION
See: https://devcenter.heroku.com/articles/rails-autoscale

I didn't actually load the gem, so nothing happened! In staging and dev we don't need to load it, so we only do it at runtime if the ENV var is set. 

This add-on allows us to trigger auto-scaling based on requests being queued up instead of relying on slow endpoints (which we have A LOT of) 