### PR TITLE
Make gem for Heroku rails-autoscale add-on actually work.

### DIFF
--- a/Gemfile.d/heroku.rb
+++ b/Gemfile.d/heroku.rb
@@ -17,6 +17,7 @@ gem "logjam_agent", github: "beyond-z/logjam_agent"
 # See: https://devcenter.heroku.com/articles/scout
 gem 'scout_apm', require: false
 
-# Auto-scaling!
+# Provides better configuration for auto-scaling dynos on Heroku
+# than the out of the box options. See:
 # See: https://elements.heroku.com/addons/rails-autoscale
-gem 'rails_autoscale_agent', require: false
+gem 'rails_autoscale_agent'  # NOTE: don't use require false. It doesn't work to load in initializer for some reason.

--- a/config/initializers/autoscale.rb
+++ b/config/initializers/autoscale.rb
@@ -1,5 +1,0 @@
-# Provides better configuration for auto-scaling dynos on Heroku
-# than the out of the box options. See:
-# https://devcenter.heroku.com/articles/rails-autoscale
-require 'rails_autoscale_agent' if ENV['RAILS_AUTOSCALE_URL']
-


### PR DESCRIPTION
For some reason, if I do "require: false" and try to require the
gem in an initializer only if configured (to save memory in dev)
it fails to add itself to Rails.application.middleware
Just require it, it's tiny.