### PR TITLE
Ignore Redis "OOM command not allowed" errors.

### DIFF
--- a/app/middleware/request_throttle.rb
+++ b/app/middleware/request_throttle.rb
@@ -162,6 +162,12 @@ class RequestThrottle
     @whitelist = @blacklist = nil
   end
 
+  # There is a bug with running LeakyBucket.lua.run(...) below in our production environment which is
+  # cloud based so we don't have access to the detailed redis config to try and workaround. 
+  # It leads to this error: OOM command not allowed when used memory > 'maxmemory'.
+  # For the time being we've disabled it using the setting below. This is fine since we don't expose 
+  # the API to anyone and don't have to worry about request throttling.
+  # See: https://github.com/antirez/redis/issues/6565
   def self.enabled?
     Setting.get("request_throttle.skip", "false") != 'true'
   end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       POSTGRES_DB: canvas
 
   canvasredis:
-    image: redis:2.6
+    image: redis:5.0.6 
     networks:
       - bravendev
 


### PR DESCRIPTION
A properly configured redis server should recover on it's own from this
and the user impact is that the key appears not to be cached, which
would just slow things down while we're in this state.

Note: see comments in code for how I've worked around the issues
leading to this error in our environment.

TESTING:
- Configured the maxmemory to be small in my dev env and confirmed
  that the OOM errors were being logged to the error report but not
  thrown. Note: login is completely broken in this state.

NOT TESTED:
- I'm 99% positive that these errors will still be sent to Sentry which
  will help with debugging. Look in ./config/initializers/sentry.rb
  and notice how it hooks into all Canvas errors logged and sends them over.
  Also, at this point, "see a blank white page, think redis"
  is instituional knowledge so if it starts happening and we don't get
  Sentry errors, we can figure that part out then.