### PR TITLE
Fix Redis OOM errors for real.

### DIFF
--- a/app/middleware/request_throttle.rb
+++ b/app/middleware/request_throttle.rb
@@ -49,6 +49,7 @@ class RequestThrottle
 
     status, headers, response = nil
     throttled = false
+
     bucket = LeakyBucket.new(client_identifier(request))
 
     cost = bucket.reserve_capacity do
@@ -281,7 +282,7 @@ class RequestThrottle
     # round trips, and possibly more when we get a transaction conflict.
     # amount and reserve_cost are passed separately for logging purposes.
     def increment(amount, reserve_cost = 0, current_time = Time.now)
-      if client_identifier.blank? || !Canvas.redis_enabled?
+      if client_identifier.blank? || !Canvas.redis_enabled? || Setting.get("request_throttle.skip", "false") == "true"
         return
       end
 


### PR DESCRIPTION
The setting to disable throttling doesn't work. There is a call
to increment in the "ensure" clause on L264. This change makes it
actually skip the call to redis and makes increment a NOOP.

TESTING:
- generally made sure stuff still works b/c this would impact all
  requests