### PR TITLE
Add more logging

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2392,45 +2392,51 @@ class ApplicationController < ActionController::Base
 
   private
   def extra_logging
-    # Clean out things we can't JSONify so it doesn't crash.
-    def filter_hash(main_hash)
-      main_hash.each_with_object({}) do |(k, v), h|
-        # remove cookie values so we don't clutter the logs
-        if(k.to_s.downcase.include? 'cookie')
-          next
-        end
-        if(v.is_a?(Hash))
-          ch = filter_hash(v)
-          h[k] = ch
-        elsif(v.is_a?(Array))
-          h[k] = v.map do |e|
-            e.is_a?(Hash) ? filter_hash(e) : e
+    data = Hash.new
+
+    begin
+      # Clean out things we can't JSONify so it doesn't crash.
+      def filter_hash(main_hash)
+        main_hash.each_with_object({}) do |(k, v), h|
+          # remove cookie values so we don't clutter the logs
+          if(k.to_s.downcase.include? 'cookie')
+            next
           end
-        elsif(v.is_a?(String))
-          h[k] = v
-        elsif(v.is_a?(Integer))
-          h[k] = v
+          if(v.is_a?(Hash))
+            ch = filter_hash(v)
+            h[k] = ch
+          elsif(v.is_a?(Array))
+            h[k] = v.map do |e|
+              e.is_a?(Hash) ? filter_hash(e) : e
+            end
+          elsif(v.is_a?(String))
+            h[k] = v
+          elsif(v.is_a?(Integer))
+            h[k] = v
+          end
         end
       end
-    end
 
-    data = {
-      'request' => {
-        'method' => request.method,
-        'headers' => filter_hash(request.headers.env),
-        'ip' => request.ip,
-        'fullpath' => request.fullpath,
-        'remote_ip' => request.remote_ip,
-        'id' => RequestContextGenerator.request_id,
-      },
-      'api_request' => @api_request,
-      'action_name' => @_action_name,
-      'session' => session.to_hash,
-      'response' => {
-        'code' => response.code,
-      },
-      'user' => @current_user,
-    }
+      data = {
+        'request' => {
+          'method' => request.method,
+          'headers' => filter_hash(request.headers.env),
+          'ip' => request.ip,
+          'fullpath' => request.fullpath,
+          'remote_ip' => request.remote_ip,
+          'id' => RequestContextGenerator.request_id,
+        },
+        'api_request' => @api_request,
+        'action_name' => @_action_name,
+        'session' => session.to_hash,
+        'response' => {
+          'code' => response.code,
+        },
+        'user' => @current_user,
+      }
+    rescue Exception => error
+      data['error_msg'] = "Error from extra_logging: #{error.to_s}"
+    end
 
     yield
 
@@ -2441,7 +2447,11 @@ class ApplicationController < ActionController::Base
     # Crash away
     raise
   ensure
-    Rails.logger.info(data.to_json)
+    begin
+      Rails.logger.info(data.to_json)
+    rescue Exception => error
+      Rails.logger.info("{\"error_msg\": \"Error from extra_logging (bad JSON): #{error.to_s}\"}")
+    end
   end
 
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -66,6 +66,8 @@ class ApplicationController < ActionController::Base
   after_filter :set_response_headers
   after_filter :update_enrollment_last_activity_at
 
+  around_filter :extra_logging
+
   add_crumb(proc {
     title = I18n.t('links.dashboard', 'My Dashboard')
     crumb = <<-END
@@ -2387,4 +2389,59 @@ class ApplicationController < ActionController::Base
       return result
     end
   end
+
+  private
+  def extra_logging
+    # Clean out things we can't JSONify so it doesn't crash.
+    def filter_hash(main_hash)
+      main_hash.each_with_object({}) do |(k, v), h|
+        # remove cookie values so we don't clutter the logs
+        if(k.to_s.downcase.include? 'cookie')
+          next
+        end
+        if(v.is_a?(Hash))
+          ch = filter_hash(v)
+          h[k] = ch
+        elsif(v.is_a?(Array))
+          h[k] = v.map do |e|
+            e.is_a?(Hash) ? filter_hash(e) : e
+          end
+        elsif(v.is_a?(String))
+          h[k] = v
+        elsif(v.is_a?(Integer))
+          h[k] = v
+        end
+      end
+    end
+
+    data = {
+      'request' => {
+        'method' => request.method,
+        'headers' => filter_hash(request.headers.env),
+        'ip' => request.ip,
+        'fullpath' => request.fullpath,
+        'remote_ip' => request.remote_ip,
+        'id' => RequestContextGenerator.request_id,
+      },
+      'api_request' => @api_request,
+      'action_name' => @_action_name,
+      'session' => session.to_hash,
+      'response' => {
+        'code' => response.code,
+      },
+      'user' => @current_user,
+    }
+
+    yield
+
+  rescue Exception => error
+    data['error_msg'] = error.to_s
+    data['response']['code'] = response_code_for_rescue(error) || 500
+
+    # Crash away
+    raise
+  ensure
+    Rails.logger.info(data.to_json)
+  end
+
 end


### PR DESCRIPTION
Add more logging to all Canvas requests. Here's what it looks like:

<details>

```json
{
  "request": {
    "method": "GET",
    "headers": {
      "rack.version": [
        1,
        3
      ],
      "SCRIPT_NAME": "",
      "QUERY_STRING": "",
      "SERVER_PROTOCOL": "HTTP\\/1.1",
      "SERVER_SOFTWARE": "puma 3.11.4 Love Song",
      "GATEWAY_INTERFACE": "CGI\\/1.2",
      "REQUEST_METHOD": "GET",
      "REQUEST_PATH": "\\/",
      "REQUEST_URI": "\\/",
      "HTTP_VERSION": "HTTP\\/1.1",
      "HTTP_HOST": "localhost:3000",
      "HTTP_CONNECTION": "keep-alive",
      "HTTP_CACHE_CONTROL": "max-age=0",
      "HTTP_UPGRADE_INSECURE_REQUESTS": "1",
      "HTTP_USER_AGENT": "Mozilla\\/5.0 ...",
      "HTTP_SEC_FETCH_USER": "?1",
      "HTTP_ACCEPT": "text\\/html,application\\/xhtml+xml,application\\/xml;q=0.9,image\\/webp,image\\/apng,*\\/*;q=0.8,application\\/signed-exchange;v=b3;q=0.9",
      "HTTP_SEC_FETCH_SITE": "cross-site",
      "HTTP_SEC_FETCH_MODE": "navigate",
      "HTTP_ACCEPT_ENCODING": "gzip, deflate, br",
      "HTTP_ACCEPT_LANGUAGE": "en-US,en;q=0.9",
      "SERVER_NAME": "localhost",
      "SERVER_PORT": "3000",
      "PATH_INFO": "\\/",
      "REMOTE_ADDR": "0.0.0.0",
      "rack.url_scheme": "http",
      "rack.after_reply": [],
      "ORIGINAL_FULLPATH": "\\/",
      "ORIGINAL_SCRIPT_NAME": "",
      "action_dispatch.parameter_filter": [
        "password",
        "auth_password",
        "access_token",
        "api_key",
        "client_secret",
        "fb_sig_friends",
        {}
      ],
      "action_dispatch.redirect_filter": [],
      "action_dispatch.secret_token": "",
      "action_dispatch.http_auth_salt": "http authentication",
      "ROUTES_36283960_SCRIPT_NAME": "",
      "RACK_MINI_PROFILER_ORIGINAL_SCRIPT_NAME": "",
      "rack.request.query_string": "",
      "rack.request.query_hash": {},
      "action_dispatch.request.query_parameters": {},
      "canvas.request_throttle.user_id": "session:ae8ad6885bc52b34104c43626da97294",
      "action_dispatch.request.path_parameters": {
        "controller": "users",
        "action": "user_dashboard"
      },
      "action_dispatch.request.request_parameters": {},
      "action_dispatch.request.parameters": {
        "controller": "users",
        "action": "user_dashboard"
      },
      "action_dispatch.request.formats": [
        {
          "synonyms": [
            "application\\/xhtml+xml"
          ],
          "symbol": "html",
          "string": "text\\/html"
        }
      ]
    },
    "ip": "0.0.0.0",
    "fullpath": "\\/",
    "remote_ip": "0.0.0.0",
    "id": "ce25f732-79db-4456-aaf8-2a91185d80cb"
  },
  "api_request": false,
  "action_name": "user_dashboard",
  "session": {
    "session_id": "ae8ad6885bc52b34104c43626da97294",
    "return_to": "http:\\/\\/localhost:3000\\/",
    "timestamp": 1111,
    "last_error_id": 1111,
    "browser_key": 1111,
    "browser_supported": true
  },
  "response": {
    "code": 500
  },
  "user": null,
  "error_msg": "error"
}
```

</details>

Notable additions:

* Actual HTTP request ID (logjam uses the wrong one somehow...)
* Session ID (can be cross-referenced with logjam messages)
* Canvas user (if logged in)
* Logs all requests, including 500s
* Error message, if there was an exception
