### PR TITLE
Only log specific user fields

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2432,8 +2432,14 @@ class ApplicationController < ActionController::Base
         'response' => {
           'code' => response.code,
         },
-        'user' => @current_user,
       }
+
+      unless @current_user.nil?
+        data['user'] = {
+          'id' => @current_user.id,
+          'name' => @current_user.name,
+        }
+      end
     rescue Exception => error
       data['error_msg'] = "Error from extra_logging: #{error.to_s}"
     end


### PR DESCRIPTION
Followup to #567 

I neglected to test what happens when you're actually logged in 🤦‍♀. Spoiler alert, `@current_user` isn't a string. This PR removes the enormous amount of unnecessary data we were dumping into the logs, and replaces it with this:

```json
"user":{"id":1,"name":"admin@beyondz.org"}
```