### PR TITLE
Adds Identifier for NCE Done Buttons and Sections

### DIFF
--- a/public/bz_support.js
+++ b/public/bz_support.js
@@ -92,10 +92,10 @@ window.addEventListener("beforeunload", function(event) {
 
 function bzRetainedInfoSetup(readonly) {
   function lockRelatedCheckboxes(el) {
-    // or if we are a graded checkbox, disable other graded checkboxes inside the same bz-box since they are all related
+    // or if we are a graded checkbox, disable other graded checkboxes inside the same bz-box/content-section since they are all related
     if(el.getAttribute("type") == "checkbox") {
       var p = el;
-      while(p && !p.classList.contains("bz-box"))
+      while(p && !p.classList.contains("bz-box") && !p.classList.contains("content-section"))
         p = p.parentNode;
       if(p) {
         var otherBoxes = p.querySelectorAll("[data-bz-retained][type=checkbox][data-bz-answer]");
@@ -283,10 +283,10 @@ function bzRetainedInfoSetup(readonly) {
         if(el.hasAttribute("data-bz-answer")) {
           // it is a mastery answer, don't actually save until the next button is pressed (if present)
           var p = el;
-          while(p && !p.classList.contains("bz-box"))
+          while(p && !p.classList.contains("bz-box") && !p.classList.contains("content-section"))
             p = p.parentNode;
           if(p) {
-            var btn = p.querySelector(".bz-toggle-all-next");
+            var btn = p.querySelector(".bz-toggle-all-next,.done-button");
             var wrapper = function() {
 	      delayedMagicFieldSaves -= 1;
               actualSave();


### PR DESCRIPTION
**Ticket(s)**:
https://app.asana.com/0/1142638035116665/1163086015979334/f
https://app.asana.com/0/1142638035116665/1155859225081689/f

**Description**:
@rshipp and I aligned that instead of creating a new `braven_support.js` file for NCE, we should just add the necessary identifiers and logic to the existing `bz_support.js`. This prevents the headache of trying to redo the entire JS for something that is structurally the same at this point. 