### PR TITLE
Fixes "bz-was-clicked" from Being Added to the Class List Every Click

### DIFF
--- a/public/bz_support.js
+++ b/public/bz_support.js
@@ -124,7 +124,7 @@ function bzRetainedInfoSetup(readonly) {
       element.checked = (value == element.value) ? true : false;
     } else if(element.tagName == "INPUT" && element.getAttribute("type") == "button"){
       if (value == "clicked"){
-       element.className += " bz-was-clicked";
+        element.classList.add("bz-was-clicked");
       }
     } else if(element.tagName == "INPUT" || element.tagName == "TEXTAREA"){
       element.value = value;


### PR DESCRIPTION
**Ticket(s)**:
https://app.asana.com/0/1142638035116665/1164735442441089

**Description**:
Currently in our Canvas, any time you click any done button on a module, the `bz-was-clicked` class will be added to it. This happens as many times you can click with can ultimately cause transversing the DOM to take an exponential amount of time.