### PR TITLE
Fixing issue where you get logged out after a day of inactivity.

### DIFF
--- a/app/controllers/login/cas_controller.rb
+++ b/app/controllers/login/cas_controller.rb
@@ -71,8 +71,6 @@ class Login::CasController < ApplicationController
         @domain_root_account.pseudonym_sessions.create!(pseudonym, false)
         session[:cas_session] = params[:ticket]
         session[:login_aac] = aac.id
-        pseudonym.claim_cas_ticket(params[:ticket])
-
         successful_login(pseudonym.user, pseudonym)
       else
         # we don't have a user, but if it was a Braven login for an NLU student, 

--- a/app/models/pseudonym.rb
+++ b/app/models/pseudonym.rb
@@ -30,7 +30,6 @@ class Pseudonym < ActiveRecord::Base
   belongs_to :authentication_provider, class_name: 'AccountAuthorizationConfig'
   MAX_UNIQUE_ID_LENGTH = 100
 
-  CAS_TICKET_EXPIRED = 'expired'
   CAS_TICKET_TTL = 1.day
 
   validates_length_of :unique_id, :maximum => MAX_UNIQUE_ID_LENGTH
@@ -540,38 +539,18 @@ class Pseudonym < ActiveRecord::Base
   end
 
   def self.cas_ticket_key(ticket)
-    "cas_session:#{ticket}"
-  end
-
-  def claim_cas_ticket(ticket)
-    return unless Canvas.redis_enabled?
-
-    redis_key = Pseudonym.cas_ticket_key(ticket)
-
-    # Refresh the keys ttl if it exists.
-    unless Canvas.redis.expire(redis_key, CAS_TICKET_TTL)
-      # If it does not exist we need to create it.
-      Canvas.redis.set(redis_key, global_id, ex: CAS_TICKET_TTL, nx: true)
-    end
+    "cas_session_slo:#{ticket}"
   end
 
   def cas_ticket_expired?(ticket)
     return unless Canvas.redis_enabled?
     redis_key = Pseudonym.cas_ticket_key(ticket)
-
-    # Refresh the ttl on the cas ticket before we check its state.
-    Canvas.redis.expire(redis_key, CAS_TICKET_TTL)
-    Canvas.redis.get(redis_key) != global_id.to_s
+    !!Canvas.redis.get(redis_key)
   end
 
   def self.expire_cas_ticket(ticket)
     return unless Canvas.redis_enabled?
     redis_key = cas_ticket_key(ticket)
-
-    if id = Canvas.redis.getset(redis_key, CAS_TICKET_EXPIRED)
-      Canvas.redis.expire(redis_key, CAS_TICKET_TTL)
-
-      Pseudonym.where(id: id).exists? if id != CAS_TICKET_EXPIRED
-    end
+    Canvas.redis.set(redis_key, true, ex: CAS_TICKET_TTL)
   end
 end


### PR DESCRIPTION
See:
- https://app.asana.com/0/search/1164889279305678/1137123576664819
- https://app.asana.com/0/search/1164889279305679/1160196877498587
- https://app.asana.com/0/search/1164889279305679/1162533377684981

Cherry-picking pieces of this commit:
 - https://github.com/instructure/canvas-lms/commit/b9490fbbe39c58cc8f2d2da248a55c51675bed9a

This is a rush job to get it live in prep for tonight's assignment being due.
I'll followup with a lot more in this area b/c the issues still persist if you actually
logout in another tab.

Test Plan:
- Open an assignment, e.g.: http://canvasweb:3000/courses/89/assignments/1872
- Fill out some fields and see that they save.
- Restart the server, which clears out the redis instance (or flush it).
- With the tab open, continue filling out fields and see they they are saving in the console and server logs.
- Logout using the Canvas logout button and make sure it logs out and you can't open the link in a new tab without logging back in.

Specs:
I also fixed up a few specs even though specs across the board have all sorts of issues. Here is what I ran:
- `RAILS_ENV=test bundle exec rake db:create db:migrate`
- `RAILS_ENV=test bundle exec rspec spec/models/pseudonym_spec.rb`

These 4 failing tests no longer fail:
```
rspec ./spec/models/pseudonym_spec.rb:362 # Pseudonym cas should claim a cas ticket
rspec ./spec/models/pseudonym_spec.rb:368 # Pseudonym cas should refresh a cas ticket
rspec ./spec/models/pseudonym_spec.rb:374 # Pseudonym cas should check cas ticket expiration
rspec ./spec/models/pseudonym_spec.rb:382 # Pseudonym cas should expire a cas ticket
```