### PR TITLE
Handle retained_data saving when logged out more gracefully.

### DIFF
--- a/app/controllers/bz_controller.rb
+++ b/app/controllers/bz_controller.rb
@@ -14,9 +14,9 @@ class BzController < ApplicationController
   # magic field dump / for cohorts uses an access token instead
   # and courses_for_email is unauthenticated since it isn't really sensitive
   # user_retained_data_batch is sensitive, but it can also be done via access_token
-  before_filter :require_user, :except => [:magic_field_dump, :courses_for_email, :magic_fields_for_cohort, :course_cohort_information, :user_retained_data_batch, :prepare_qualtrics_links]
+  before_filter :require_user, :except => [:magic_field_dump, :courses_for_email, :magic_fields_for_cohort, :course_cohort_information, :user_retained_data_batch, :user_retained_data, :set_user_retained_data, :prepare_qualtrics_links]
+  before_filter :require_user_render_json_unauthorized, :only => [:user_retained_data, :set_user_retained_data]
   skip_before_filter :verify_authenticity_token, :only => [:last_user_url, :set_user_retained_data, :delete_user, :user_retained_data_batch, :prepare_qualtrics_links]
-
 
   # used by the pdf annotator
   def submission_comment

--- a/app/views/layouts/_foot.html.erb
+++ b/app/views/layouts/_foot.html.erb
@@ -140,6 +140,9 @@
 <div style="display: none;" id="bz-late-warning">
   You will not receive credit for this module because it is past due.
 </div>
+<div style="display: none;" id="bz-logged-out-warning">
+  You've been logged out and data can't be saved. You'll be redirected to log back in now.
+</div>
 
 
 <script type="application/json" id="my-current-cohort-json"><%= current_cohort.to_json.gsub("/script", "").html_safe %></script>

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -57,9 +57,9 @@
       }
       document.addEventListener('click', _earlyClick);
   </script>
-  <script src="/bz_support.js?20190813"></script>
+  <script src="/bz_support.js?20200304"></script>
   <script src="/DragDropTouch.js"></script>
-  <link rel="stylesheet" type="text/css" href="/bz_support.css?20190416" />
+  <link rel="stylesheet" type="text/css" href="/bz_support.css?20200304" />
   <%= render 'shared/google_analytics' %>
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700,300,600,400' rel='stylesheet' type='text/css'>
   <link href="/font/TradeGothicNo.20-CondBold.css" rel="stylesheet" type="text/css" />

--- a/public/bz_support.css
+++ b/public/bz_support.css
@@ -79,6 +79,22 @@
   padding-top: 0.5em;
 }
 
+#bz-logged-out-warning {
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  z-index: 1500;
+  background-color: #ffff88;
+  height: 2.5em;
+  width: 100%;
+  margin: 0px;
+  color: black;
+  font-weight: bold;
+  text-align: center;
+  font-size: 14pt;
+  padding: 0.25em;
+  padding-top: 0.5em;
+}
 /*
  The point of this is to hide the element for a while until the scripts get a chance to run,
  so it doesn't freak out students by flashing it for a while.

--- a/public/bz_support.js
+++ b/public/bz_support.js
@@ -746,6 +746,26 @@ function BZ_SaveMagicField(field_name, field_value, optional, type, answer, weig
             BZ_SaveMagicField(field_name, field_value, optional, type, answer);
           }, 5000);
           BZ_MagicFieldSaveTimeouts[field_name] = timeout;
+        } else if(http.status == 401) {
+          // Their session isn' valid and they're logged out. Flash a message and redirect 
+          // to login. This will come up as soon as they try to edit a field while logged 
+          // out and a prompt that their work hasn't saved (in addition to the message about 
+          // why) will ask if they want to leave. They can hit cancel to go save that field 
+          // in a notepad or something if they don't want to lose it.
+          var loggedOutWarning = document.getElementById("bz-logged-out-warning");
+          if(loggedOutWarning) {
+            loggedOutWarning.style.display = "";
+          }
+          var err = JSON.parse(http.responseText);
+          var redirectURL = err["login_url"];
+          // Give it a sec for them to see the message and then redirect them to login.
+          var timeout = setTimeout(function() {
+            if(redirectURL) {
+              window.location.href = redirectURL;
+            } else {
+              window.location.href = window.location.protocol + "//" + window.location.host + "/login";
+            }
+          }, 1500);
         } else {
           // returned error from Canvas...
           // should be a code error on our side


### PR DESCRIPTION
Before this change, if they had a tab left open to an assignment or module and they got logged out somehow. E.g the session expired or they logged out from a different tab or browser, the user could
continue filling out fields and it would warn that data wasn't saving b/c they weren't connected to the internet. If the user continued filling out fields, for each one, a retry would kickoff in the background every 5 seconds. This lead to:

1) Users freaking out b/c they would do a ton of work and it wouldn't save even though
   they were connected to the internet
2) Our servers being hammered with calls to set_user_retained_data if several users
   got into this situation and left their tabs open. For example, in one week we saw
   1.16 million calls to this endpoint -- far surpassing what would be expected for 500
   currently enrolled students.

Note: this problem was exacerbated by a separate bug which caused you to get logged out
after 1 day of inactivity, so tabs left open for a day would start to exhibit this behavior.
That was fixed here: https://github.com/beyond-z/canvas-lms/pull/572

This change detects a logout, flashes a message about it, and redirects them to login:
![image](https://user-images.githubusercontent.com/5596986/76095312-11664380-5f92-11ea-9c8c-c4fd337bb7c0.png)

**Test Plan:**
1. Login and fill out some fields in an assignment.
2. In a separate tab, hit the Logout button.
3. In the original tab, continue filling out fields.
4. Notice that the message about being logged out is shown instructing them they're being redirected
   and then a prompt comes up telling them their data didn't save and asking if they want to leave anyway.
5. Try the cancel button and make sure it keeps trying to redirect if they keep trying to fill out fields.

- Repeat the above steps but try each of the following instead of step 4 above:
  - Logout in a different browser
  - Clear the cookies
  - Do a server restart => expected behavior is that they are still logged in and none of this stuff happens.

- Repeat the above steps for a module.
- Repeat the above steps with the dynamic syllabus (aka Course Home) loaded for regression purposes to make sure that when they click something the normal redirect behavior happens.