### PR TITLE
Support optional-magic-field as a data attribute

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -57,7 +57,7 @@
       }
       document.addEventListener('click', _earlyClick);
   </script>
-  <script src="/bz_support.js?20200304"></script>
+  <script src="/bz_support.js?20200319"></script>
   <script src="/DragDropTouch.js"></script>
   <link rel="stylesheet" type="text/css" href="/bz_support.css?20200304" />
   <%= render 'shared/google_analytics' %>

--- a/lib/bz_grading.rb
+++ b/lib/bz_grading.rb
@@ -113,7 +113,7 @@ class BZGrading
     context_module = get_context_module(module_item_id)
 
     names = {}
-    selector = 'input[data-bz-retained]:not(.bz-optional-magic-field),textarea[data-bz-retained]:not(.bz-optional-magic-field)'
+    selector = 'input[data-bz-retained]:not(.bz-optional-magic-field):not([data-bz-optional-magic-field="true"]),textarea[data-bz-retained]:not(.bz-optional-magic-field):not([data-bz-optional-magic-field="true"])'
 
     # Loop over the Wiki Pages in this module
     items_in_module = context_module.content_tags.active

--- a/public/bz_support.js
+++ b/public/bz_support.js
@@ -90,6 +90,14 @@ window.addEventListener("beforeunload", function(event) {
   }
 });
 
+function bzIsOptionalMagicField(el) {
+  if (el.classList.contains("bz-optional-magic-field") || el.getAttribute("data-bz-optional-magic-field") == "true") {
+    return true;
+  } else {
+    return false;
+  }
+}
+
 function bzRetainedInfoSetup(readonly) {
   function lockRelatedCheckboxes(el) {
     // or if we are a graded checkbox, disable other graded checkboxes inside the same bz-box/content-section since they are all related
@@ -199,7 +207,7 @@ function bzRetainedInfoSetup(readonly) {
           el.className += " bz-was-clicked";
         }
         var optional = false;
-        if (el.classList.contains("bz-optional-magic-field"))
+        if (bzIsOptionalMagicField(el))
           optional = true;
 
         var actualSaveInternal = function() {
@@ -435,7 +443,7 @@ function validateMagicFields() {
 
   var list = document.querySelectorAll("#assignment_show .description input[type=text][data-bz-retained], #assignment_show .description input[type=url][data-bz-retained], #assignment_show .description textarea[data-bz-retained]");
   for(var a = 0; a < list.length; a++) {
-    if(list[a].value == "" && !list[a].classList.contains("bz-optional-magic-field")) {
+    if(list[a].value == "" && !bzIsOptionalMagicField(list[a])) {
       if(firstValidateMagicFieldsTest == null || firstValidateMagicFieldsTest != list[a]) {
         firstValidateMagicFieldsTest = list[a];
         alert('You have incomplete fields in this project. Go back and complete them before submitting.');
@@ -541,7 +549,7 @@ function bzActivateInstantSurvey(magic_field_name) {
 	var inputs = i.querySelectorAll("input");
 	for(var a = 0; a < inputs.length; a++) {
 		inputs[a].onchange = function() {
-			save(this.value, this.classList.contains("bz-optional-magic-field"));
+			save(this.value, bzIsOptionalMagicField(this));
 		};
 	}
 }


### PR DESCRIPTION
Adds support for the new "data-bz-optional-magic-field" attribute to the Canvas JS and grading lib.

Related: https://github.com/bebraven/platform/pull/121, https://github.com/bebraven/platform/pull/123

Task: https://app.asana.com/0/1142638035116665/1165345563821545/f

Note: We don't have a great way to test this yet. See https://app.asana.com/0/1142638035116665/1166448997769280/f.